### PR TITLE
Add user profile sync via data layer

### DIFF
--- a/common/src/main/kotlin/researchstack/data/local/room/WearableAppDataBase.kt
+++ b/common/src/main/kotlin/researchstack/data/local/room/WearableAppDataBase.kt
@@ -17,6 +17,7 @@ import researchstack.data.local.room.dao.PpgIrDao
 import researchstack.data.local.room.dao.PpgRedDao
 import researchstack.data.local.room.dao.SpO2Dao
 import researchstack.data.local.room.dao.SweatLossDao
+import researchstack.data.local.room.dao.UserProfileDao
 import researchstack.data.local.room.entity.PassiveDataStatusEntity
 import researchstack.domain.model.priv.Accelerometer
 import researchstack.domain.model.priv.Bia
@@ -27,9 +28,10 @@ import researchstack.domain.model.priv.PpgIr
 import researchstack.domain.model.priv.PpgRed
 import researchstack.domain.model.priv.SpO2
 import researchstack.domain.model.priv.SweatLoss
+import researchstack.domain.model.UserProfile
 
 @Database(
-    version = 2,
+    version = 3,
     exportSchema = false,
 
     entities = [
@@ -43,6 +45,7 @@ import researchstack.domain.model.priv.SweatLoss
         SweatLoss::class,
         HeartRate::class,
         PassiveDataStatusEntity::class,
+        UserProfile::class,
     ],
 )
 @TypeConverters(
@@ -62,6 +65,7 @@ abstract class WearableAppDataBase : RoomDatabase() {
     abstract fun sweatLossDao(): SweatLossDao
     abstract fun heartRateDao(): HeartRateDao
     abstract fun passiveDataStatusDao(): PassiveDataStatusDao
+    abstract fun userProfileDao(): UserProfileDao
 
     companion object {
         @Volatile

--- a/common/src/main/kotlin/researchstack/data/local/room/dao/UserProfileDao.kt
+++ b/common/src/main/kotlin/researchstack/data/local/room/dao/UserProfileDao.kt
@@ -1,0 +1,8 @@
+package researchstack.data.local.room.dao
+
+import androidx.room.Dao
+import researchstack.domain.model.USER_PROFILE_TABLE_NAME
+import researchstack.domain.model.UserProfile
+
+@Dao
+abstract class UserProfileDao : PrivDao<UserProfile>(USER_PROFILE_TABLE_NAME)

--- a/common/src/main/kotlin/researchstack/domain/model/UserProfile.kt
+++ b/common/src/main/kotlin/researchstack/domain/model/UserProfile.kt
@@ -1,12 +1,22 @@
 package researchstack.domain.model
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import researchstack.util.getCurrentTimeOffset
+import researchstack.domain.model.Timestamp
+
+const val USER_PROFILE_TABLE_NAME = "user_profile"
+
+@Entity(tableName = USER_PROFILE_TABLE_NAME)
 data class UserProfile(
     var height: Float,
     var weight: Float,
     var yearBirth: Int,
     var gender: Gender,
     var isMetricUnit: Boolean? = null,
-)
+    @PrimaryKey override val timestamp: Long = 0,
+    override val timeOffset: Int = getCurrentTimeOffset(),
+) : Timestamp
 
 fun UserProfile?.isValid(): Boolean =
     this != null && yearBirth > 0 && gender != Gender.UNKNOWN && height > 0f && weight > 0f && isMetricUnit != null
@@ -16,3 +26,4 @@ enum class Gender {
     MALE,
     UNKNOWN,
 }
+

--- a/common/src/main/kotlin/researchstack/domain/model/priv/PrivDataType.kt
+++ b/common/src/main/kotlin/researchstack/domain/model/priv/PrivDataType.kt
@@ -1,5 +1,6 @@
 package researchstack.domain.model.priv
 
+import researchstack.domain.model.UserProfile
 import researchstack.domain.model.shealth.HealthTypeEnum
 import kotlin.reflect.KClass
 
@@ -13,6 +14,7 @@ enum class PrivDataType(val messagePath: String, val isPassive: Boolean = false)
     WEAR_SPO2("/spo2_data"),
     WEAR_SWEAT_LOSS("/sweat_loss_data"),
     WEAR_HEART_RATE("/heart_rate_data", true),
+    WEAR_USER_PROFILE("/user_profile"),
     ;
 
     companion object {
@@ -26,6 +28,7 @@ enum class PrivDataType(val messagePath: String, val isPassive: Boolean = false)
             SpO2::class -> WEAR_SPO2
             SweatLoss::class -> WEAR_SWEAT_LOSS
             HeartRate::class -> WEAR_HEART_RATE
+            UserProfile::class -> WEAR_USER_PROFILE
             else -> throw IllegalArgumentException("${model::class.simpleName} is not PrivDataType")
         }
     }

--- a/common/src/test/kotlin/researchstack/model/PrivDataTypeTest.kt
+++ b/common/src/test/kotlin/researchstack/model/PrivDataTypeTest.kt
@@ -16,6 +16,7 @@ import researchstack.domain.model.priv.PpgRed
 import researchstack.domain.model.priv.PrivDataType
 import researchstack.domain.model.priv.SpO2
 import researchstack.domain.model.priv.SweatLoss
+import researchstack.domain.model.UserProfile
 
 class PrivDataTypeTest {
 
@@ -32,6 +33,7 @@ class PrivDataTypeTest {
             SpO2::class,
             SweatLoss::class,
             HeartRate::class,
+            UserProfile::class,
         )
         val expectedPrivDataTypes = listOf(
             PrivDataType.WEAR_ACCELEROMETER,
@@ -43,6 +45,7 @@ class PrivDataTypeTest {
             PrivDataType.WEAR_SPO2,
             PrivDataType.WEAR_SWEAT_LOSS,
             PrivDataType.WEAR_HEART_RATE,
+            PrivDataType.WEAR_USER_PROFILE,
         )
         val actualPrivDataTypes = models.map { PrivDataType.fromModel(it) }
         assertEquals(expectedPrivDataTypes, actualPrivDataTypes)

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/grpc/mapper/HealthDataGrpcMapper.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/grpc/mapper/HealthDataGrpcMapper.kt
@@ -53,6 +53,7 @@ private fun PrivDataType.toGrpcHealthDataType() = when (this) {
     PrivDataType.WEAR_SPO2 -> HealthDataType.HEALTH_DATA_TYPE_WEAR_SPO2
     PrivDataType.WEAR_SWEAT_LOSS -> HealthDataType.HEALTH_DATA_TYPE_WEAR_SWEAT_LOSS
     PrivDataType.WEAR_HEART_RATE -> HealthDataType.HEALTH_DATA_TYPE_WEAR_HEART_RATE
+    PrivDataType.WEAR_USER_PROFILE -> HealthDataType.HEALTH_DATA_TYPE_UNSPECIFIED
 }
 
 private fun DeviceStatDataType.toGrpcHealthDataType() = when (this) {

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/wearable/WearableDataReceiverRepositoryImpl.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/wearable/WearableDataReceiverRepositoryImpl.kt
@@ -38,6 +38,7 @@ import researchstack.domain.model.priv.PpgRed
 import researchstack.domain.model.priv.PrivDataType
 import researchstack.domain.model.priv.SpO2
 import researchstack.domain.model.priv.SweatLoss
+import researchstack.domain.model.UserProfile
 import researchstack.domain.model.shealth.HealthDataModel
 import researchstack.domain.repository.ShareAgreementRepository
 import researchstack.domain.repository.StudyRepository
@@ -103,6 +104,7 @@ class WearableDataReceiverRepositoryImpl @Inject constructor(
             PrivDataType.WEAR_SPO2 -> saveData<SpO2>(jsonObject, wearableAppDataBase.spO2Dao())
             PrivDataType.WEAR_SWEAT_LOSS -> saveData<SweatLoss>(jsonObject, wearableAppDataBase.sweatLossDao())
             PrivDataType.WEAR_HEART_RATE -> saveData<HeartRate>(jsonObject, wearableAppDataBase.heartRateDao())
+            PrivDataType.WEAR_USER_PROFILE -> saveData<UserProfile>(jsonObject, wearableAppDataBase.userProfileDao())
         }
     }
 
@@ -136,6 +138,11 @@ class WearableDataReceiverRepositoryImpl @Inject constructor(
             PrivDataType.WEAR_HEART_RATE -> saveData<HeartRate>(
                 readCsv<HeartRate>(csvInputStream),
                 wearableAppDataBase.heartRateDao()
+            )
+
+            PrivDataType.WEAR_USER_PROFILE -> saveData<UserProfile>(
+                readCsv<UserProfile>(csvInputStream),
+                wearableAppDataBase.userProfileDao()
             )
         }
     }
@@ -211,6 +218,7 @@ class WearableDataReceiverRepositoryImpl @Inject constructor(
             PrivDataType.WEAR_SPO2 -> readCsv<SpO2>(csvInputStream)
             PrivDataType.WEAR_SWEAT_LOSS -> readCsv<SweatLoss>(csvInputStream)
             PrivDataType.WEAR_HEART_RATE -> readCsv<HeartRate>(csvInputStream)
+            PrivDataType.WEAR_USER_PROFILE -> readCsv<UserProfile>(csvInputStream)
         }
 
         grpcHealthDataSynchronizer.syncHealthData(
@@ -254,6 +262,7 @@ class WearableDataReceiverRepositoryImpl @Inject constructor(
             PrivDataType.WEAR_SPO2 -> wearableAppDataBase.spO2Dao()
             PrivDataType.WEAR_SWEAT_LOSS -> wearableAppDataBase.sweatLossDao()
             PrivDataType.WEAR_HEART_RATE -> wearableAppDataBase.heartRateDao()
+            PrivDataType.WEAR_USER_PROFILE -> wearableAppDataBase.userProfileDao()
         }
 
     private suspend fun <T : TimestampMapData> syncRoomToServer(

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/util/HealthDataStringResource.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/util/HealthDataStringResource.kt
@@ -41,6 +41,7 @@ private fun PrivDataType.toStringResourceId(): Int =
         PrivDataType.WEAR_SPO2 -> string.wear_spo2
         PrivDataType.WEAR_SWEAT_LOSS -> string.wear_sweat_loss
         PrivDataType.WEAR_HEART_RATE -> string.wear_heart_rate
+        PrivDataType.WEAR_USER_PROFILE -> string.wear_user_profile
     }
 
 private fun DeviceStatDataType.toStringResourceId(): Int =

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -115,6 +115,7 @@
   <string name="wear_spo2">SpO2</string>
   <string name="wear_sweat_loss">Sweat Loss</string>
   <string name="wear_heart_rate">Heart Rate</string>
+  <string name="wear_user_profile">User Profile</string>
   <string name="wear_blood_pressure">Blood Pressure</string>
 
   <string name="device_stat_mobile_wear_connection">device name</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
   <string name="wear_spo2">산소포화도</string>
   <string name="wear_sweat_loss">땀 손실</string>
   <string name="wear_heart_rate">심박수</string>
+  <string name="wear_user_profile">사용자 프로필</string>
   <string name="wear_blood_pressure">혈압</string>
 
   <string name="device_stat_mobile_wear_connection">연결된 워치 정보</string>

--- a/samples/starter-wearable-app/src/main/kotlin/researchstack/domain/usecase/SendUserProfileUseCase.kt
+++ b/samples/starter-wearable-app/src/main/kotlin/researchstack/domain/usecase/SendUserProfileUseCase.kt
@@ -1,0 +1,13 @@
+package researchstack.domain.usecase
+
+import researchstack.domain.model.UserProfile
+import researchstack.domain.model.priv.PrivDataType
+import researchstack.domain.repository.DataSenderRepository
+import javax.inject.Inject
+
+class SendUserProfileUseCase @Inject constructor(
+    private val dataSenderRepository: DataSenderRepository,
+) {
+    suspend operator fun invoke(userProfile: UserProfile) =
+        dataSenderRepository.sendData(userProfile, PrivDataType.WEAR_USER_PROFILE)
+}

--- a/samples/starter-wearable-app/src/main/kotlin/researchstack/presentation/measurement/viewmodel/BiaMeasureViewModel.kt
+++ b/samples/starter-wearable-app/src/main/kotlin/researchstack/presentation/measurement/viewmodel/BiaMeasureViewModel.kt
@@ -20,6 +20,7 @@ import researchstack.domain.model.priv.PrivDataType
 import researchstack.domain.usecase.TrackDataUseCase
 import researchstack.domain.usecase.TrackMeasureTimeUseCase
 import researchstack.domain.usecase.UserProfileUseCase
+import researchstack.domain.usecase.SendUserProfileUseCase
 import researchstack.presentation.main.screen.HomeScreenItem
 import researchstack.presentation.main.screen.getItemPrefKey
 import researchstack.presentation.measurement.screen.AskProfilePage
@@ -34,6 +35,7 @@ class BiaMeasureViewModel @Inject constructor(
     private val trackMeasureTimeUseCase: TrackMeasureTimeUseCase,
     private val trackDataUseCase: TrackDataUseCase,
     private val userProfileUseCase: UserProfileUseCase,
+    private val sendUserProfileUseCase: SendUserProfileUseCase,
 ) : AndroidViewModel(application) {
 
     private val _measureState = MutableLiveData<MeasureState>(None)
@@ -199,6 +201,7 @@ class BiaMeasureViewModel @Inject constructor(
         profile?.let {
             viewModelScope.launch(Dispatchers.IO) {
                 userProfileUseCase(it)
+                sendUserProfileUseCase(it)
             }
         }
     }


### PR DESCRIPTION
## Summary
- support new WEAR_USER_PROFILE data type in PrivDataType and tests
- store wearable user profile in database
- receive user profile on mobile and insert via repository
- map new data type to resources
- send user profile from watch when saved

## Testing
- `./gradlew :common:test :samples:starter-mobile-app:test :samples:starter-wearable-app:test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879aa690ec832faed518d918febf7c