### PR TITLE
Save enrollment date on study join

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/pref/EnrollmentDatePref.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/pref/EnrollmentDatePref.kt
@@ -1,0 +1,20 @@
+package researchstack.data.datasource.local.pref
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.firstOrNull
+
+class EnrollmentDatePref(private val dataStore: DataStore<Preferences>) {
+    suspend fun saveEnrollmentDate(studyId: String, date: String) {
+        dataStore.edit { preferences ->
+            preferences[stringPreferencesKey(studyId)] = date
+        }
+    }
+
+    suspend fun getEnrollmentDate(studyId: String): String? =
+        dataStore.data.firstOrNull()?.let { pref ->
+            pref[stringPreferencesKey(studyId)]
+        }
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/study/StudyViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/study/StudyViewModel.kt
@@ -18,6 +18,7 @@ import researchstack.data.datasource.local.pref.SyncTimePref.SyncTimePrefKey.CAL
 import researchstack.data.datasource.local.pref.SyncTimePref.SyncTimePrefKey.PLACE_EVENT_SYNC
 import researchstack.data.datasource.local.pref.SyncTimePref.SyncTimePrefKey.PRESENCE_EVENT_SYNC
 import researchstack.data.datasource.local.pref.SyncTimePref.SyncTimePrefKey.USAGE_STATS_SAVE
+import researchstack.data.datasource.local.pref.EnrollmentDatePref
 import researchstack.data.datasource.local.pref.dataStore
 import researchstack.domain.exception.AlreadyJoinedStudy
 import researchstack.domain.model.ShareAgreement
@@ -34,6 +35,7 @@ import researchstack.presentation.service.TrackerDataForegroundService
 import researchstack.presentation.worker.FetchStudyTasksWorker
 import researchstack.presentation.worker.FetchStudyTasksWorker.Companion.STUDY_ID_KEY
 import java.time.Instant
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -81,6 +83,8 @@ constructor(
         studyId: String,
     ) {
         setSyncTimestamp()
+        EnrollmentDatePref(getApplication<Application>().applicationContext.dataStore)
+            .saveEnrollmentDate(studyId, LocalDate.now().toString())
         fetchStudyTasksWithWorker(studyId)
 
         studyShardViewModel.participationRequirement.value?.apply {


### PR DESCRIPTION
## Summary
- add `EnrollmentDatePref` to store join dates in `DataStore`
- record current date when joining a study

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888f0b0dfc832f92779b98776078c3