### PR TITLE
Handle AlreadyJoinedStudy

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/usecase/study/FetchJoinedStudiesUseCase.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/usecase/study/FetchJoinedStudiesUseCase.kt
@@ -1,0 +1,11 @@
+package researchstack.domain.usecase.study
+
+import researchstack.domain.repository.StudyRepository
+import javax.inject.Inject
+
+class FetchJoinedStudiesUseCase @Inject constructor(
+    private val studyRepository: StudyRepository
+) {
+    suspend operator fun invoke(): Unit = studyRepository.fetchJoinedStudiesFromNetwork()
+}
+

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/study/StudyViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/study/StudyViewModel.kt
@@ -28,6 +28,7 @@ import researchstack.domain.model.priv.PrivDataType
 import researchstack.domain.model.sensor.TrackerDataType
 import researchstack.domain.model.shealth.SHealthDataType
 import researchstack.domain.usecase.shareagreement.ShareAgreementUseCase
+import researchstack.domain.usecase.study.FetchJoinedStudiesUseCase
 import researchstack.domain.usecase.study.StudyJoinUseCase
 import researchstack.domain.usecase.wearable.PassiveDataStatusUseCase
 import researchstack.domain.usecase.wearable.WearablePassiveDataStatusSenderUseCase
@@ -45,6 +46,7 @@ constructor(
     application: Application,
     private val studyShardViewModel: SharedStudyJoinViewModel,
     private val studyJoinUseCase: StudyJoinUseCase,
+    private val fetchJoinedStudiesUseCase: FetchJoinedStudiesUseCase,
     private val shareAgreementUseCase: ShareAgreementUseCase,
     private val passiveDataStatusUseCase: PassiveDataStatusUseCase,
     private val wearablePassiveDataStatusUseCase: WearablePassiveDataStatusSenderUseCase,
@@ -68,6 +70,7 @@ constructor(
             }.onFailure { ex ->
                 val message =
                     if (ex is AlreadyJoinedStudy) {
+                        fetchJoinedStudiesUseCase()
                         onJoinStudy(studyId)
                         getApplication<Application>().applicationContext.getString(R.string.already_joined_study)
                     } else {

--- a/samples/starter-mobile-app/src/test/kotlin/researchstack/domain/usecase/study/FetchJoinedStudiesUseCaseTest.kt
+++ b/samples/starter-mobile-app/src/test/kotlin/researchstack/domain/usecase/study/FetchJoinedStudiesUseCaseTest.kt
@@ -1,0 +1,25 @@
+package researchstack.domain.usecase.study
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import researchstack.NEGATIVE_TEST
+import researchstack.domain.repository.StudyRepository
+
+internal class FetchJoinedStudiesUseCaseTest {
+    private val studyRepository = mockk<StudyRepository>()
+    private val fetchJoinedStudiesUseCase = FetchJoinedStudiesUseCase(studyRepository)
+
+    @Test
+    @Tag(NEGATIVE_TEST)
+    fun `should throw exception when repository fails`() = runTest {
+        coEvery { studyRepository.fetchJoinedStudiesFromNetwork() } throws IllegalStateException()
+
+        assertThrows<Exception> {
+            fetchJoinedStudiesUseCase()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add FetchJoinedStudiesUseCase
- inject FetchJoinedStudiesUseCase in StudyViewModel
- when join fails due to AlreadyJoinedStudy, refresh joined studies
- add failing test for the new usecase

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688894c57aa0832fbb0a1b2fbbdbe996