### PR TITLE
Add weekNumber to Exercise data

### DIFF
--- a/common/src/main/kotlin/researchstack/domain/model/healthConnect/Exercise.kt
+++ b/common/src/main/kotlin/researchstack/domain/model/healthConnect/Exercise.kt
@@ -32,6 +32,8 @@ data class Exercise(
     val status: Int = 0,
     val meanSpeed: Double = 0.0,
     val maxSpeed: Double = 0.0,
+    @SerializedName("week_number")
+    val weekNumber: Int = 0,
     override val timeOffset: Int = getCurrentTimeOffset(),
 ) : TimestampMapData {
     override fun toDataMap(): Map<String, Any> =
@@ -51,6 +53,7 @@ data class Exercise(
             "max_speed" to maxSpeed,
             "mean_speed" to meanSpeed,
             "status" to status,
+            "week_number" to weekNumber,
             "time_offset" to timeOffset,
         )
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/HealthConnectProvider.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/HealthConnectProvider.kt
@@ -18,6 +18,8 @@ import researchstack.domain.repository.StudyRepository
 import researchstack.domain.repository.healthConnect.HealthConnectDataSyncRepository
 import researchstack.domain.usecase.file.UploadFileUseCase
 import researchstack.domain.usecase.profile.GetProfileUseCase
+import researchstack.data.datasource.local.pref.EnrollmentDatePref
+import researchstack.data.datasource.local.pref.dataStore
 import javax.inject.Singleton
 
 @Module
@@ -31,6 +33,7 @@ class HealthConnectProvider {
     @Singleton
     @Provides
     fun provideHealthConnectDataSyncRepository(
+        @ApplicationContext context: Context,
         healthConnectDataSource: HealthConnectDataSource,
         shareAgreementDao: ShareAgreementDao,
         studyRepository: StudyRepository,
@@ -40,7 +43,14 @@ class HealthConnectProvider {
         studyDao: StudyDao,
         grpcHealthDataSynchronizer: GrpcHealthDataSynchronizer<HealthDataModel>
     ): HealthConnectDataSyncRepository = HealthConnectDataSyncRepositoryImpl(
-        healthConnectDataSource, shareAgreementDao, studyRepository,
-        shareAgreementRepository, uploadFileUseCase, getProfileUseCase,studyDao,grpcHealthDataSynchronizer
+        healthConnectDataSource,
+        shareAgreementDao,
+        studyRepository,
+        shareAgreementRepository,
+        uploadFileUseCase,
+        getProfileUseCase,
+        studyDao,
+        EnrollmentDatePref(context.dataStore),
+        grpcHealthDataSynchronizer
     )
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
@@ -20,6 +20,7 @@ import researchstack.domain.repository.healthConnect.HealthConnectDataSyncReposi
 import researchstack.domain.usecase.file.UploadFileUseCase
 import researchstack.domain.usecase.log.AppLogger
 import researchstack.domain.usecase.profile.GetProfileUseCase
+import researchstack.data.datasource.local.pref.EnrollmentDatePref
 import javax.inject.Inject
 
 class HealthConnectDataSyncRepositoryImpl @Inject constructor(
@@ -30,6 +31,7 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
     private val uploadFileUseCase: UploadFileUseCase,
     private val getProfileUseCase: GetProfileUseCase,
     private val studyDao: StudyDao,
+    private val enrollmentDatePref: EnrollmentDatePref,
     private val grpcHealthDataSynchronizer: GrpcHealthDataSynchronizer<HealthDataModel>
 ) : HealthConnectDataSyncRepository {
     override suspend fun syncHealthData() {
@@ -44,7 +46,8 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
                         val items = mutableListOf<Exercise>()
                         exerciseRecords.forEach { record ->
                             val sessionData = healthConnectDataSource.getAggregateData(record.metadata.id)
-                            val exercise = processExerciseData(record, sessionData)
+                            val studyId = studyRepository.getActiveStudies().first().firstOrNull()?.id ?: ""
+                            val exercise = processExerciseData(record, sessionData, studyId, enrollmentDatePref)
                             items.add(exercise)
                         }
                         items


### PR DESCRIPTION
## Summary
- extend Exercise model with week number
- compute enrollment week when parsing exercise records
- inject EnrollmentDatePref into health data sync

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_68889ae4e0cc832fad858f5f15cc9e2f