### PR TITLE
Add database storage for exercises

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/DaoProvider.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/DaoProvider.kt
@@ -17,6 +17,7 @@ import researchstack.data.datasource.local.room.dao.ShareAgreementDao
 import researchstack.data.datasource.local.room.dao.SpeedDao
 import researchstack.data.datasource.local.room.dao.StudyDao
 import researchstack.data.datasource.local.room.dao.TaskDao
+import researchstack.data.datasource.local.room.dao.ExerciseDao
 import researchstack.data.local.room.WearableAppDataBase
 import researchstack.data.local.room.dao.PassiveDataStatusDao
 import javax.inject.Singleton
@@ -60,6 +61,11 @@ object DaoProvider {
     @Provides
     fun provideSpeedDao(@ApplicationContext context: Context): SpeedDao =
         ResearchAppDatabase.getDatabase(context).speedDao()
+
+    @Singleton
+    @Provides
+    fun provideExerciseDao(@ApplicationContext context: Context): ExerciseDao =
+        ResearchAppDatabase.getDatabase(context).exerciseDao()
 
     @Singleton
     @Provides

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/HealthConnectProvider.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/HealthConnectProvider.kt
@@ -11,6 +11,7 @@ import researchstack.backend.integration.GrpcHealthDataSynchronizer
 import researchstack.data.datasource.healthConnect.HealthConnectDataSource
 import researchstack.data.datasource.local.room.dao.ShareAgreementDao
 import researchstack.data.datasource.local.room.dao.StudyDao
+import researchstack.data.datasource.local.room.dao.ExerciseDao
 import researchstack.data.repository.healthConnect.HealthConnectDataSyncRepositoryImpl
 import researchstack.domain.model.shealth.HealthDataModel
 import researchstack.domain.repository.ShareAgreementRepository
@@ -41,6 +42,7 @@ class HealthConnectProvider {
         uploadFileUseCase: UploadFileUseCase,
         getProfileUseCase: GetProfileUseCase,
         studyDao: StudyDao,
+        exerciseDao: ExerciseDao,
         grpcHealthDataSynchronizer: GrpcHealthDataSynchronizer<HealthDataModel>
     ): HealthConnectDataSyncRepository = HealthConnectDataSyncRepositoryImpl(
         healthConnectDataSource,
@@ -50,6 +52,7 @@ class HealthConnectProvider {
         uploadFileUseCase,
         getProfileUseCase,
         studyDao,
+        exerciseDao,
         EnrollmentDatePref(context.dataStore),
         grpcHealthDataSynchronizer
     )

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/ResearchAppDatabase.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/ResearchAppDatabase.kt
@@ -18,6 +18,7 @@ import researchstack.data.datasource.local.room.dao.LogDao
 import researchstack.data.datasource.local.room.dao.ParticipationRequirementDao
 import researchstack.data.datasource.local.room.dao.ShareAgreementDao
 import researchstack.data.datasource.local.room.dao.SpeedDao
+import researchstack.data.datasource.local.room.dao.ExerciseDao
 import researchstack.data.datasource.local.room.dao.StudyDao
 import researchstack.data.datasource.local.room.dao.TaskDao
 import researchstack.data.datasource.local.room.entity.AppLogEntity
@@ -28,11 +29,12 @@ import researchstack.data.datasource.local.room.entity.ShareAgreementEntity
 import researchstack.data.datasource.local.room.entity.Speed
 import researchstack.data.datasource.local.room.entity.StudyEntity
 import researchstack.data.datasource.local.room.entity.TaskEntity
+import researchstack.domain.model.healthConnect.Exercise
 import researchstack.domain.model.sensor.Accelerometer
 import researchstack.domain.model.sensor.Light
 
 @Database(
-    version = 4,
+    version = 5,
     exportSchema = false,
     entities = [
         StudyEntity::class,
@@ -43,6 +45,7 @@ import researchstack.domain.model.sensor.Light
         Accelerometer::class,
         AppLogEntity::class,
         Speed::class,
+        Exercise::class,
         FileUploadRequestEntity::class,
         EventEntity::class,
     ],
@@ -63,6 +66,7 @@ abstract class ResearchAppDatabase : RoomDatabase() {
     abstract fun shareAgreementDao(): ShareAgreementDao
     abstract fun lightDao(): LightDao
     abstract fun speedDao(): SpeedDao
+    abstract fun exerciseDao(): ExerciseDao
     abstract fun accelerometerDao(): AccelerometerDao
     abstract fun logDao(): LogDao
     abstract fun fileUploadRequestDao(): FileUploadRequestDao

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/dao/ExerciseDao.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/dao/ExerciseDao.kt
@@ -1,0 +1,8 @@
+package researchstack.data.datasource.local.room.dao
+
+import androidx.room.Dao
+import researchstack.domain.model.healthConnect.EXERCISE_TABLE_NAME
+import researchstack.domain.model.healthConnect.Exercise
+
+@Dao
+abstract class ExerciseDao : TimestampEntityBaseDao<Exercise>(EXERCISE_TABLE_NAME)

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
@@ -8,6 +8,7 @@ import researchstack.data.datasource.healthConnect.HealthConnectDataSource
 import researchstack.data.datasource.healthConnect.processExerciseData
 import researchstack.data.datasource.local.room.dao.ShareAgreementDao
 import researchstack.data.datasource.local.room.dao.StudyDao
+import researchstack.data.datasource.local.room.dao.ExerciseDao
 import researchstack.domain.model.Study
 import researchstack.domain.model.TimestampMapData
 import researchstack.domain.model.healthConnect.Exercise
@@ -33,6 +34,7 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
     private val uploadFileUseCase: UploadFileUseCase,
     private val getProfileUseCase: GetProfileUseCase,
     private val studyDao: StudyDao,
+    private val exerciseDao: ExerciseDao,
     private val enrollmentDatePref: EnrollmentDatePref,
     private val grpcHealthDataSynchronizer: GrpcHealthDataSynchronizer<HealthDataModel>
 ) : HealthConnectDataSyncRepository {
@@ -65,6 +67,7 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
                                 items.add(exercise)
                             }
                         }
+                        exerciseDao.insertAll(*items.toTypedArray())
                         items
                     }
 


### PR DESCRIPTION
## Summary
- add ExerciseDao to persist exercise sessions
- include Exercise entity in ResearchAppDatabase
- expose ExerciseDao through DaoProvider
- inject ExerciseDao into HealthConnectProvider
- store exercise data in syncHealthData

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888af87676c832faa25cd7f8fceed6e