### PR TITLE
Simplify weekly exercise query

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/dao/ExerciseDao.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/dao/ExerciseDao.kt
@@ -1,8 +1,14 @@
 package researchstack.data.datasource.local.room.dao
 
 import androidx.room.Dao
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 import researchstack.domain.model.healthConnect.EXERCISE_TABLE_NAME
 import researchstack.domain.model.healthConnect.Exercise
 
 @Dao
-abstract class ExerciseDao : TimestampEntityBaseDao<Exercise>(EXERCISE_TABLE_NAME)
+abstract class ExerciseDao : TimestampEntityBaseDao<Exercise>(EXERCISE_TABLE_NAME) {
+
+    @Query("SELECT * FROM $EXERCISE_TABLE_NAME WHERE startTime >= :from ORDER BY startTime ASC")
+    abstract fun getExercisesFrom(from: Long): Flow<List<Exercise>>
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -58,9 +58,13 @@ import researchstack.presentation.component.ComplianceSummaryCard
 import researchstack.presentation.initiate.route.Route
 import researchstack.presentation.screen.notification.NotificationViewModel
 import researchstack.presentation.viewmodel.HealthConnectPermissionViewModel
+import researchstack.presentation.viewmodel.DashboardViewModel
 
 @Composable
-fun DashboardScreen(healthConnectPermissionViewModel: HealthConnectPermissionViewModel = hiltViewModel()) {
+fun DashboardScreen(
+    healthConnectPermissionViewModel: HealthConnectPermissionViewModel = hiltViewModel(),
+    dashboardViewModel: DashboardViewModel = hiltViewModel()
+) {
     val context = LocalContext.current
     val weeklyTab = stringResource(id = R.string.weekly)
     var activeTab by remember { mutableStateOf(weeklyTab) }
@@ -69,6 +73,7 @@ fun DashboardScreen(healthConnectPermissionViewModel: HealthConnectPermissionVie
     val navController = LocalNavController.current
     val notificationViewModel: NotificationViewModel = hiltViewModel()
     val hasUnread by notificationViewModel.hasUnread.collectAsState()
+    val exercises by dashboardViewModel.exercises.collectAsState()
 
     val permissionsLauncher =
         rememberLauncherForActivityResult(healthConnectPermissionViewModel.permissionsLauncher) {
@@ -251,6 +256,11 @@ fun DashboardScreen(healthConnectPermissionViewModel: HealthConnectPermissionVie
                                     stringResource(id = R.string.bia),
                                     0.70f,
                                     Color(0xFFFFA500)
+                                )
+                                Text(
+                                    "Exercises this week: ${exercises.size}",
+                                    color = Color.White,
+                                    modifier = Modifier.padding(top = 8.dp)
                                 )
                             }
                         }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
@@ -1,0 +1,54 @@
+package researchstack.presentation.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import researchstack.data.datasource.local.pref.EnrollmentDatePref
+import researchstack.data.datasource.local.pref.dataStore
+import researchstack.data.datasource.local.room.dao.ExerciseDao
+import researchstack.domain.model.healthConnect.Exercise
+import researchstack.domain.repository.StudyRepository
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+@HiltViewModel
+class DashboardViewModel @Inject constructor(
+    application: Application,
+    private val studyRepository: StudyRepository,
+    private val exerciseDao: ExerciseDao,
+) : AndroidViewModel(application) {
+
+    private val enrollmentDatePref = EnrollmentDatePref(application.dataStore)
+
+    private val _exercises = MutableStateFlow<List<Exercise>>(emptyList())
+    val exercises: StateFlow<List<Exercise>> = _exercises
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            val studyId = studyRepository.getActiveStudies().firstOrNull()?.firstOrNull()?.id
+            if (studyId != null) {
+                val enrollmentDate = enrollmentDatePref.getEnrollmentDate(studyId)
+                enrollmentDate?.let { dateString ->
+                    val weekStart = calculateCurrentWeekStart(LocalDate.parse(dateString))
+                    val startMillis = weekStart.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                    exerciseDao.getExercisesFrom(startMillis).collect { _exercises.value = it }
+                }
+            }
+        }
+    }
+
+    private fun calculateCurrentWeekStart(enrollmentDate: LocalDate): LocalDate {
+        val today = LocalDate.now()
+        val days = ChronoUnit.DAYS.between(enrollmentDate, today)
+        val weeks = days / 7
+        return enrollmentDate.plusWeeks(weeks)
+    }
+}


### PR DESCRIPTION
## Summary
- return only exercises after a given start time
- use the updated query in DashboardViewModel

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888c1f2f9f8832f85c912d238d0d7c6