### PR TITLE
Track activity progress

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -75,6 +75,7 @@ fun DashboardScreen(
     val hasUnread by notificationViewModel.hasUnread.collectAsState()
     val exercises by dashboardViewModel.exercises.collectAsState()
     val totalDuration by dashboardViewModel.totalDurationMinutes.collectAsState()
+    val activityProgressPercent by dashboardViewModel.activityProgressPercent.collectAsState()
 
     val activityDurationDisplay = remember(totalDuration) {
         val hours = totalDuration / 60
@@ -246,22 +247,22 @@ fun DashboardScreen(
                             ) {
                                 ProgressBarItem(
                                     stringResource(id = R.string.activity),
-                                    0.85f,
+                                    activityProgressPercent,
                                     Color(0xFF00A86B)
                                 )
                                 ProgressBarItem(
                                     stringResource(id = R.string.resistance),
-                                    0.60f,
+                                    60,
                                     Color(0xFFFFD700)
                                 )
                                 ProgressBarItem(
                                     stringResource(id = R.string.weight),
-                                    0.30f,
+                                    30,
                                     Color(0xFFFF6347)
                                 )
                                 ProgressBarItem(
                                     stringResource(id = R.string.bia),
-                                    0.70f,
+                                    70,
                                     Color(0xFFFFA500)
                                 )
                                 Text(
@@ -367,9 +368,16 @@ fun TabButton(label: String, selected: Boolean, onClick: () -> Unit) {
 }
 
 @Composable
-fun ProgressBarItem(label: String, progress: Float, color: Color) {
+fun ProgressBarItem(label: String, progressPercent: Int, color: Color) {
+    val progressFraction = (progressPercent.coerceIn(0, 100)) / 100f
     Column {
-        Text(label, color = Color.White, fontSize = 15.sp)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(label, color = Color.White, fontSize = 15.sp)
+            Text("${progressPercent}%", color = Color.White, fontSize = 15.sp)
+        }
         Spacer(Modifier.height(6.dp))
         Box(
             Modifier
@@ -380,7 +388,7 @@ fun ProgressBarItem(label: String, progress: Float, color: Color) {
             Box(
                 Modifier
                     .fillMaxHeight()
-                    .fillMaxWidth(progress)
+                    .fillMaxWidth(progressFraction)
                     .background(color, RoundedCornerShape(50))
             )
         }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
@@ -27,6 +27,10 @@ class DashboardViewModel @Inject constructor(
     private val exerciseDao: ExerciseDao,
 ) : AndroidViewModel(application) {
 
+    companion object {
+        const val ACTIVITY_GOAL_MINUTES = 150
+    }
+
     private val enrollmentDatePref = EnrollmentDatePref(application.dataStore)
 
     private val _exercises = MutableStateFlow<List<Exercise>>(emptyList())
@@ -34,6 +38,9 @@ class DashboardViewModel @Inject constructor(
 
     private val _totalDurationMinutes = MutableStateFlow(0L)
     val totalDurationMinutes: StateFlow<Long> = _totalDurationMinutes
+
+    private val _activityProgressPercent = MutableStateFlow(0)
+    val activityProgressPercent: StateFlow<Int> = _activityProgressPercent
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -46,7 +53,10 @@ class DashboardViewModel @Inject constructor(
                     exerciseDao.getExercisesFrom(startMillis).collect { list ->
                         _exercises.value = list
                         val totalMillis = list.sumOf { it.endTime - it.startTime }
-                        _totalDurationMinutes.value = TimeUnit.MILLISECONDS.toMinutes(totalMillis)
+                        val minutes = TimeUnit.MILLISECONDS.toMinutes(totalMillis)
+                        _totalDurationMinutes.value = minutes
+                        val progress = ((minutes * 100f) / ACTIVITY_GOAL_MINUTES).coerceAtMost(100f)
+                        _activityProgressPercent.value = progress.toInt()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add constant and progress percent calculation in `DashboardViewModel`
- show activity progress percent in `DashboardScreen`
- simplify `ProgressBarItem` to accept a percent and render progress fraction internally

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ce1ba310832faeefd9847ec52f3a