### PR TITLE
Implement pull-to-refresh on dashboard

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -28,6 +28,9 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -37,6 +40,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,6 +76,15 @@ fun DashboardScreen(
     val totalDuration by dashboardViewModel.totalDurationMinutes.collectAsState()
     val activityProgressPercent by dashboardViewModel.activityProgressPercent.collectAsState()
 
+    var refreshing by remember { mutableStateOf(false) }
+    val pullRefreshState = rememberPullRefreshState(refreshing) {
+        refreshing = true
+        dashboardViewModel.refreshData()
+    }
+    LaunchedEffect(exercises) {
+        refreshing = false
+    }
+
     val activityDurationDisplay = remember(totalDuration) {
         val hours = totalDuration / 60
         val minutes = totalDuration % 60
@@ -86,6 +99,7 @@ fun DashboardScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFF222222))
+            .pullRefresh(pullRefreshState)
     ) {
         Column(
             modifier = Modifier
@@ -329,6 +343,11 @@ fun DashboardScreen(
                 }
             }
         }
+        PullRefreshIndicator(
+            refreshing = refreshing,
+            state = pullRefreshState,
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- enable pull-to-refresh gesture on `DashboardScreen`
- invoke `refreshData` in `DashboardViewModel` when pulling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e421204c832f9d7bcb925fb22f47