### PR TITLE
feat: add weekly progress screen

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
@@ -15,6 +15,7 @@ enum class Route {
     Login,
     Intro,
     Notifications,
+    WeeklyProgress,
 }
 
 enum class MainPage {

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -10,6 +10,7 @@ import researchstack.presentation.screen.insight.SettingScreen
 import researchstack.presentation.screen.insight.StudyPermissionSettingScreen
 import researchstack.presentation.screen.insight.StudyStatusScreen
 import researchstack.presentation.screen.main.MainScreen
+import researchstack.presentation.screen.main.WeeklyProgressScreen
 import researchstack.presentation.screen.notification.NotificationScreen
 import researchstack.presentation.screen.study.EligibilityFailScreen
 import researchstack.presentation.screen.study.StudyCodeInputScreen
@@ -36,6 +37,9 @@ fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) 
         }
         composable(Route.Notifications.name) {
             NotificationScreen()
+        }
+        composable(Route.WeeklyProgress.name) {
+            WeeklyProgressScreen()
         }
         composable(Route.Welcome.name) {
             WelcomeScreen()

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
@@ -1,0 +1,228 @@
+package researchstack.presentation.screen.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.ui.res.stringResource
+import researchstack.R
+import researchstack.presentation.viewmodel.WeeklyProgressViewModel
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Composable
+fun WeeklyProgressScreen(
+    viewModel: WeeklyProgressViewModel = hiltViewModel(),
+) {
+    val weekDays by viewModel.weekDays.collectAsState()
+    val selectedDate by viewModel.selectedDate.collectAsState()
+    val activityMinutes by viewModel.activityMinutes.collectAsState()
+    val resistanceMinutes by viewModel.resistanceMinutes.collectAsState()
+    val activityProgress by viewModel.activityProgressPercent.collectAsState()
+    val resistanceProgress by viewModel.resistanceProgressPercent.collectAsState()
+    val hasData by viewModel.hasData.collectAsState()
+    val weekStart by viewModel.weekStart.collectAsState()
+    val canPrev by viewModel.canNavigatePrevious.collectAsState()
+    val canNext by viewModel.canNavigateNext.collectAsState()
+
+    val today = LocalDate.now()
+    val dateFormatter = DateTimeFormatter.ofPattern("dd MMMM yyyy")
+    val rangeFormatter = DateTimeFormatter.ofPattern("MMM d")
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF222222))
+            .verticalScroll(rememberScrollState())
+    ) {
+        Text(
+            text = stringResource(id = R.string.today) + ", " + today.format(dateFormatter),
+            modifier = Modifier.padding(start = 24.dp, top = 24.dp, end = 24.dp),
+            color = Color.White,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Medium
+        )
+        Spacer(Modifier.height(16.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { viewModel.navigateWeek(-1) }, enabled = canPrev) {
+                Icon(
+                    Icons.Default.ArrowBack,
+                    contentDescription = null,
+                    tint = if (canPrev) Color.White else Color.Gray
+                )
+            }
+            Text(
+                text = weekStart.format(rangeFormatter) + " - " + weekStart.plusDays(6).format(rangeFormatter),
+                color = Color.White,
+                fontWeight = FontWeight.Medium
+            )
+            IconButton(onClick = { viewModel.navigateWeek(1) }, enabled = canNext) {
+                Icon(
+                    Icons.Default.ArrowForward,
+                    contentDescription = null,
+                    tint = if (canNext) Color.White else Color.Gray
+                )
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 24.dp)
+        ) {
+            items(weekDays) { date ->
+                val selected = date == selectedDate
+                val dayName = date.format(DateTimeFormatter.ofPattern("EEE", Locale.getDefault()))
+                val dayNum = date.format(DateTimeFormatter.ofPattern("dd"))
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .clickable { viewModel.selectDate(date) }
+                        .background(
+                            if (selected) Color.White else Color(0xFF333333),
+                            RoundedCornerShape(12.dp)
+                        )
+                        .padding(vertical = 8.dp, horizontal = 12.dp)
+                ) {
+                    Text(
+                        text = dayName,
+                        color = if (selected) Color.Black else Color.White,
+                        fontSize = 14.sp
+                    )
+                    Text(
+                        text = dayNum,
+                        color = if (selected) Color.Black else Color.White,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(24.dp))
+        if (hasData) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                ProgressCard(
+                    title = stringResource(id = R.string.activity),
+                    minutes = activityMinutes,
+                    progressPercent = activityProgress,
+                    color = Color(0xFF00A86B)
+                )
+                ProgressCard(
+                    title = stringResource(id = R.string.resistance),
+                    minutes = resistanceMinutes,
+                    progressPercent = resistanceProgress,
+                    color = Color(0xFFFFD700)
+                )
+            }
+        } else {
+            Text(
+                text = stringResource(id = R.string.no_data_available),
+                color = Color.White,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+            )
+        }
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun ProgressCard(
+    title: String,
+    minutes: Int,
+    progressPercent: Int,
+    color: Color,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(Color(0xFF333333)),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            VerticalProgressBar(progressPercent, color)
+            Column {
+                Text(title, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                Text(
+                    stringResource(
+                        id = R.string.minutes_out_of,
+                        minutes,
+                        WeeklyProgressViewModel.ACTIVITY_GOAL_MINUTES
+                    ),
+                    color = Color.White,
+                    fontSize = 14.sp
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VerticalProgressBar(progressPercent: Int, color: Color) {
+    val progress = progressPercent.coerceIn(0, 100) / 100f
+    Box(
+        modifier = Modifier
+            .width(8.dp)
+            .height(80.dp)
+            .background(Color(0xFF374151), RoundedCornerShape(50))
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(progress)
+                .align(Alignment.BottomCenter)
+                .background(color, RoundedCornerShape(50))
+        )
+    }
+}
+

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
@@ -1,0 +1,155 @@
+package researchstack.presentation.viewmodel
+
+import android.app.Application
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import researchstack.data.datasource.local.pref.EnrollmentDatePref
+import researchstack.data.datasource.local.pref.dataStore
+import researchstack.data.datasource.local.room.dao.ExerciseDao
+import researchstack.domain.repository.StudyRepository
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+@HiltViewModel
+class WeeklyProgressViewModel @Inject constructor(
+    application: Application,
+    private val studyRepository: StudyRepository,
+    private val exerciseDao: ExerciseDao,
+) : AndroidViewModel(application) {
+
+    companion object {
+        const val ACTIVITY_GOAL_MINUTES = 150
+    }
+
+    private val enrollmentDatePref = EnrollmentDatePref(application.dataStore)
+
+    private var enrollmentDate: LocalDate? = null
+    private var currentWeekIndex = 0
+    private var maxWeekIndex = 0
+    private var progressJob: Job? = null
+
+    private val _weekStart = MutableStateFlow(LocalDate.now())
+    val weekStart: StateFlow<LocalDate> = _weekStart
+
+    private val _weekDays = MutableStateFlow<List<LocalDate>>(emptyList())
+    val weekDays: StateFlow<List<LocalDate>> = _weekDays
+
+    private val _selectedDate = MutableStateFlow(LocalDate.now())
+    val selectedDate: StateFlow<LocalDate> = _selectedDate
+
+    private val _activityMinutes = MutableStateFlow(0)
+    val activityMinutes: StateFlow<Int> = _activityMinutes
+
+    private val _resistanceMinutes = MutableStateFlow(0)
+    val resistanceMinutes: StateFlow<Int> = _resistanceMinutes
+
+    private val _activityProgressPercent = MutableStateFlow(0)
+    val activityProgressPercent: StateFlow<Int> = _activityProgressPercent
+
+    private val _resistanceProgressPercent = MutableStateFlow(0)
+    val resistanceProgressPercent: StateFlow<Int> = _resistanceProgressPercent
+
+    private val _hasData = MutableStateFlow(true)
+    val hasData: StateFlow<Boolean> = _hasData
+
+    private val _canNavigatePrevious = MutableStateFlow(false)
+    val canNavigatePrevious: StateFlow<Boolean> = _canNavigatePrevious
+
+    private val _canNavigateNext = MutableStateFlow(false)
+    val canNavigateNext: StateFlow<Boolean> = _canNavigateNext
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            val studyId = studyRepository.getActiveStudies().firstOrNull()?.firstOrNull()?.id
+            if (studyId != null) {
+                enrollmentDate = enrollmentDatePref.getEnrollmentDate(studyId)?.let { LocalDate.parse(it) }
+                enrollmentDate?.let { start ->
+                    val today = LocalDate.now()
+                    val days = ChronoUnit.DAYS.between(start, today).toInt().coerceAtLeast(0)
+                    currentWeekIndex = days / 7
+                    maxWeekIndex = currentWeekIndex
+                    _weekStart.value = start.plusDays((currentWeekIndex * 7).toLong())
+                    _weekDays.value = (0..6).map { _weekStart.value.plusDays(it.toLong()) }
+                    _selectedDate.value = if (today in _weekDays.value) today else _weekStart.value
+                    updateNavigationButtons()
+                    loadProgressForDate(_selectedDate.value)
+                }
+            }
+        }
+    }
+
+    fun navigateWeek(offset: Int) {
+        val newIndex = currentWeekIndex + offset
+        if (newIndex < 0 || newIndex > maxWeekIndex) return
+        currentWeekIndex = newIndex
+        enrollmentDate?.let { start ->
+            _weekStart.value = start.plusDays((currentWeekIndex * 7).toLong())
+            _weekDays.value = (0..6).map { _weekStart.value.plusDays(it.toLong()) }
+            val today = LocalDate.now()
+            _selectedDate.value = if (today in _weekDays.value) today else _weekStart.value
+            updateNavigationButtons()
+            loadProgressForDate(_selectedDate.value)
+        }
+    }
+
+    fun selectDate(date: LocalDate) {
+        _selectedDate.value = date
+        loadProgressForDate(date)
+    }
+
+    private fun loadProgressForDate(date: LocalDate) {
+        progressJob?.cancel()
+        progressJob = viewModelScope.launch(Dispatchers.IO) {
+            val startMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            val endMillis = date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            exerciseDao.getExercisesFrom(startMillis).collect { list ->
+                val dayList = list.filter { it.startTime < endMillis }
+                val resistanceList = dayList.filter { isResistance(it.exerciseType.toInt()) }
+                val exerciseList = dayList.filterNot { isResistance(it.exerciseType.toInt()) }
+
+                val totalMillis = exerciseList.sumOf { it.endTime - it.startTime }
+                val minutes = TimeUnit.MILLISECONDS.toMinutes(totalMillis).toInt()
+                _activityMinutes.value = minutes
+
+                val resistanceMillis = resistanceList.sumOf { it.endTime - it.startTime }
+                val resistanceMinutes = TimeUnit.MILLISECONDS.toMinutes(resistanceMillis).toInt()
+                _resistanceMinutes.value = resistanceMinutes
+
+                _activityProgressPercent.value =
+                    ((minutes * 100f) / ACTIVITY_GOAL_MINUTES).coerceAtMost(100f).toInt()
+                _resistanceProgressPercent.value =
+                    ((resistanceMinutes * 100f) / ACTIVITY_GOAL_MINUTES).coerceAtMost(100f).toInt()
+
+                _hasData.value = dayList.isNotEmpty()
+            }
+        }
+    }
+
+    private fun updateNavigationButtons() {
+        _canNavigatePrevious.value = currentWeekIndex > 0
+        _canNavigateNext.value = currentWeekIndex < maxWeekIndex
+    }
+
+    private fun isResistance(exerciseType: Int): Boolean {
+        return when (exerciseType) {
+            ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING,
+            ExerciseSessionRecord.EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING,
+            ExerciseSessionRecord.EXERCISE_TYPE_PILATES,
+            ExerciseSessionRecord.EXERCISE_TYPE_STRETCHING,
+            ExerciseSessionRecord.EXERCISE_TYPE_YOGA,
+            ExerciseSessionRecord.EXERCISE_TYPE_CALISTHENICS -> true
+            else -> false
+        }
+    }
+}
+

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -189,4 +189,7 @@
     <string name="sync_success">Data sync successful</string>
     <string name="sync_success_with_type">%1$s 데이터 동기화 완료</string>
 
+    <string name="today">Today</string>
+    <string name="no_data_available">No data available</string>
+    <string name="minutes_out_of">%1$d out of %2$d minutes</string>
 </resources>


### PR DESCRIPTION
## Summary
- add navigation route and strings for weekly progress view
- implement WeeklyProgressScreen with week navigation, date selector, and progress cards
- create WeeklyProgressViewModel to compute weekly ranges and progress

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af72238c0832fa5365ad12db495ec