### PR TITLE
Add top bar to weekly progress screen

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -35,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.res.stringResource
 import researchstack.R
+import researchstack.presentation.LocalNavController
 import researchstack.presentation.viewmodel.WeeklyProgressViewModel
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -44,6 +46,7 @@ import java.util.Locale
 fun WeeklyProgressScreen(
     viewModel: WeeklyProgressViewModel = hiltViewModel(),
 ) {
+    val navController = LocalNavController.current
     val weekDays by viewModel.weekDays.collectAsState()
     val activityMinutes by viewModel.activityMinutes.collectAsState()
     val resistanceMinutes by viewModel.resistanceMinutes.collectAsState()
@@ -58,12 +61,41 @@ fun WeeklyProgressScreen(
     val dateFormatter = DateTimeFormatter.ofPattern("dd MMMM yyyy")
     val rangeFormatter = DateTimeFormatter.ofPattern("MMM d")
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color(0xFF222222))
-            .verticalScroll(rememberScrollState())
-    ) {
+    Scaffold(
+        containerColor = Color(0xFF222222),
+        topBar = {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black)
+                    .padding(16.dp)
+            ) {
+                IconButton(
+                    onClick = { navController.popBackStack() },
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        Icons.Default.ArrowBack,
+                        contentDescription = stringResource(id = R.string.close),
+                        tint = Color.White
+                    )
+                }
+                Text(
+                    text = stringResource(id = R.string.weekly_progress),
+                    color = Color.White,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 20.sp,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+        ) {
         Text(
             text = stringResource(id = R.string.today) + ", " + today.format(dateFormatter),
             modifier = Modifier.padding(start = 24.dp, top = 24.dp, end = 24.dp),

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -166,9 +166,10 @@
     <string name="close">Close</string>
     <string name="sync">Sync</string>
     <string name="sync_now">Sync Now</string>
-    <string name="activity_tab">Activity</string>
-    <string name="notifications">Notifications</string>
-    <string name="mark_as_read">Mark as read</string>
+  <string name="activity_tab">Activity</string>
+  <string name="notifications">Notifications</string>
+  <string name="weekly_progress">Weekly Progress</string>
+  <string name="mark_as_read">Mark as read</string>
     <string name="enable_notifications">Enable notifications</string>
     <string name="enable_dark_mode">Enable dark mode</string>
     <string name="bank">Bank</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -183,6 +183,7 @@
     <string name="sync_now">Sync Now</string>
     <string name="activity_tab">Activity</string>
     <string name="notifications">Notifications</string>
+    <string name="weekly_progress">Weekly Progress</string>
     <string name="mark_as_read">Mark as read</string>
     <string name="enable_notifications">Enable notifications</string>
     <string name="enable_dark_mode">Enable dark mode</string>


### PR DESCRIPTION
## Summary
- add centered top navigation bar with back action to Weekly Progress screen
- provide string resources for Weekly Progress title

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(failed: build did not progress beyond buildSrc tasks)*

------
https://chatgpt.com/codex/tasks/task_e_688b09d53b54832f973e9cea9b848f8e