### PR TITLE
feat: show weekly exercise details

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
@@ -1,0 +1,62 @@
+package researchstack.presentation.screen.main
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import researchstack.R
+import researchstack.presentation.viewmodel.ExerciseDetailUi
+
+@Composable
+fun ExerciseDetailSheet(title: String, exercises: List<ExerciseDetailUi>) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Text(title, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+        Spacer(Modifier.height(16.dp))
+        if (exercises.isEmpty()) {
+            Text(
+                text = stringResource(id = R.string.no_activity_data_week),
+                color = Color.White
+            )
+        } else {
+            LazyColumn {
+                items(exercises) { exercise ->
+                    ExerciseDetailItem(exercise)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExerciseDetailItem(detail: ExerciseDetailUi) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Text(detail.name, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        Text("${detail.startTime} - ${detail.endTime}", color = Color.White, fontSize = 14.sp)
+        Text(
+            text = stringResource(id = R.string.duration_minutes, detail.durationMinutes),
+            color = Color.White,
+            fontSize = 14.sp
+        )
+        Text("${stringResource(id = R.string.calories)}: ${detail.calories}", color = Color.White, fontSize = 14.sp)
+        Text("${stringResource(id = R.string.min_hr)}: ${detail.minHeartRate}", color = Color.White, fontSize = 14.sp)
+        Text("${stringResource(id = R.string.max_hr)}: ${detail.maxHeartRate}", color = Color.White, fontSize = 14.sp)
+    }
+}

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -193,4 +193,11 @@
     <string name="today">Today</string>
     <string name="no_data_available">No data available</string>
     <string name="minutes_out_of">%1$d out of %2$d minutes</string>
+    <string name="activity_details">Activity Details</string>
+    <string name="resistance_details">Resistance Details</string>
+    <string name="no_activity_data_week">No activity data for this week.</string>
+    <string name="calories">Calories</string>
+    <string name="min_hr">Min HR</string>
+    <string name="max_hr">Max HR</string>
+    <string name="duration_minutes">Duration: %1$d min</string>
 </resources>


### PR DESCRIPTION
## Summary
- move exercise filtering and formatting to `WeeklyProgressViewModel`
- extract `ExerciseDetailSheet` into its own file
- open bottom sheet with preformatted activity or resistance details

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b15148adc832f8e6ec2990159c3e0