### PR TITLE
feat: enhance exercise detail sheet UI

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
@@ -1,13 +1,22 @@
 package researchstack.presentation.screen.main
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -27,12 +36,28 @@ fun ExerciseDetailSheet(title: String, exercises: List<ExerciseDetailUi>) {
         Text(title, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 18.sp)
         Spacer(Modifier.height(16.dp))
         if (exercises.isEmpty()) {
-            Text(
-                text = stringResource(id = R.string.no_activity_data_week),
-                color = Color.White
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.FitnessCenter,
+                    contentDescription = null,
+                    tint = Color.LightGray,
+                    modifier = Modifier.size(48.dp)
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(id = R.string.no_activity_data_week),
+                    color = Color.White
+                )
+            }
         } else {
-            LazyColumn {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
                 items(exercises) { exercise ->
                     ExerciseDetailItem(exercise)
                 }
@@ -43,20 +68,39 @@ fun ExerciseDetailSheet(title: String, exercises: List<ExerciseDetailUi>) {
 
 @Composable
 private fun ExerciseDetailItem(detail: ExerciseDetailUi) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp)
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFF333333)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
-        Text(detail.name, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
-        Text("${detail.startTime} - ${detail.endTime}", color = Color.White, fontSize = 14.sp)
-        Text(
-            text = stringResource(id = R.string.duration_minutes, detail.durationMinutes),
-            color = Color.White,
-            fontSize = 14.sp
-        )
-        Text("${stringResource(id = R.string.calories)}: ${detail.calories}", color = Color.White, fontSize = 14.sp)
-        Text("${stringResource(id = R.string.min_hr)}: ${detail.minHeartRate}", color = Color.White, fontSize = 14.sp)
-        Text("${stringResource(id = R.string.max_hr)}: ${detail.maxHeartRate}", color = Color.White, fontSize = 14.sp)
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(detail.name, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+            Text(detail.date, color = Color.LightGray, fontSize = 14.sp)
+            Text("${detail.startTime} – ${detail.endTime}", color = Color.White, fontSize = 14.sp)
+            Text(
+                text = stringResource(id = R.string.duration_minutes, detail.durationMinutes),
+                color = Color.LightGray,
+                fontSize = 14.sp
+            )
+            Text(
+                "${stringResource(id = R.string.calories)}: ${detail.calories}",
+                color = Color.LightGray,
+                fontSize = 14.sp
+            )
+            Text(
+                "${stringResource(id = R.string.min_hr)}: ${detail.minHeartRate}",
+                color = Color.LightGray,
+                fontSize = 14.sp
+            )
+            Text(
+                "${stringResource(id = R.string.max_hr)}: ${detail.maxHeartRate}",
+                color = Color.LightGray,
+                fontSize = 14.sp
+            )
+        }
     }
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
@@ -82,7 +82,9 @@ fun WeeklyProgressScreen(
         }
         ModalBottomSheet(
             onDismissRequest = { detailType = null },
-            sheetState = sheetState
+            sheetState = sheetState,
+            containerColor = Color(0xFF222222),
+            modifier = Modifier.fillMaxHeight()
         ) {
             ExerciseDetailSheet(
                 title = if (detailType == DetailType.Resistance)

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
@@ -38,6 +38,7 @@ class WeeklyProgressViewModel @Inject constructor(
     }
 
     private val timeFormatter = DateTimeFormatter.ofPattern("hh:mm a", Locale.getDefault())
+    private val dateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy", Locale.getDefault())
 
     private val enrollmentDatePref = EnrollmentDatePref(application.dataStore)
 
@@ -151,20 +152,18 @@ class WeeklyProgressViewModel @Inject constructor(
     }
 
     private fun Exercise.toDetailUi(): ExerciseDetailUi {
-        val start = Instant.ofEpochMilli(startTime)
-            .atZone(ZoneId.systemDefault())
-            .toLocalTime()
-            .format(timeFormatter)
-        val end = Instant.ofEpochMilli(endTime)
-            .atZone(ZoneId.systemDefault())
-            .toLocalTime()
-            .format(timeFormatter)
+        val startInstant = Instant.ofEpochMilli(startTime).atZone(ZoneId.systemDefault())
+        val endInstant = Instant.ofEpochMilli(endTime).atZone(ZoneId.systemDefault())
+        val start = startInstant.toLocalTime().format(timeFormatter)
+        val end = endInstant.toLocalTime().format(timeFormatter)
+        val date = startInstant.toLocalDate().format(dateFormatter)
         val name = exerciseName.ifBlank {
             EXERCISE_TYPE_INT_TO_STRING_MAP[exerciseType.toInt()] ?: ""
         }
         val duration = TimeUnit.MILLISECONDS.toMinutes(endTime - startTime).toInt()
         return ExerciseDetailUi(
             name = name,
+            date = date,
             startTime = start,
             endTime = end,
             durationMinutes = duration,
@@ -190,6 +189,7 @@ class WeeklyProgressViewModel @Inject constructor(
 
 data class ExerciseDetailUi(
     val name: String,
+    val date: String,
     val startTime: String,
     val endTime: String,
     val durationMinutes: Int,


### PR DESCRIPTION
## Summary
- add date field and formatting for exercise details
- redesign detail bottom sheet with dark theme cards and empty state
- ensure bottom sheet uses app background color

## Testing
- `./gradlew :samples:starter-mobile-app:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b1ecf9b8c832f9e74c8f60f3787f8