### PR TITLE
Refactor ExerciseDetailItem layout

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
@@ -2,6 +2,7 @@ package researchstack.presentation.screen.main
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -79,29 +80,92 @@ private fun ExerciseDetailItem(detail: ExerciseDetailUi) {
             modifier = Modifier.padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            Text(detail.name, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 16.sp)
-            Text(detail.date, color = Color.LightGray, fontSize = 14.sp)
-            Text("${detail.startTime} – ${detail.endTime}", color = Color.White, fontSize = 14.sp)
             Text(
-                text = stringResource(id = R.string.duration_minutes, detail.durationMinutes),
-                color = Color.LightGray,
-                fontSize = 14.sp
+                detail.name,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 20.sp
             )
-            Text(
-                "${stringResource(id = R.string.calories)}: ${detail.calories}",
-                color = Color.LightGray,
-                fontSize = 14.sp
-            )
-            Text(
-                "${stringResource(id = R.string.min_hr)}: ${detail.minHeartRate}",
-                color = Color.LightGray,
-                fontSize = 14.sp
-            )
-            Text(
-                "${stringResource(id = R.string.max_hr)}: ${detail.maxHeartRate}",
-                color = Color.LightGray,
-                fontSize = 14.sp
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(id = R.string.date_label),
+                    color = Color.LightGray,
+                    fontSize = 16.sp
+                )
+                Text(detail.date, color = Color.White, fontSize = 14.sp)
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(id = R.string.time_label),
+                    color = Color.LightGray,
+                    fontSize = 16.sp
+                )
+                Text(
+                    "${detail.startTime} – ${detail.endTime}",
+                    color = Color.White,
+                    fontSize = 14.sp
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(id = R.string.duration_label),
+                    color = Color.LightGray,
+                    fontSize = 16.sp
+                )
+                Text(
+                    "${detail.durationMinutes} ${stringResource(id = R.string.minutes_short)}",
+                    color = Color.White,
+                    fontSize = 14.sp
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(id = R.string.calories),
+                    color = Color.LightGray,
+                    fontSize = 16.sp
+                )
+                Text("${detail.calories}", color = Color.White, fontSize = 14.sp)
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(id = R.string.min_hr),
+                    color = Color.LightGray,
+                    fontSize = 16.sp
+                )
+                Text("${detail.minHeartRate}", color = Color.White, fontSize = 14.sp)
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(id = R.string.max_hr),
+                    color = Color.LightGray,
+                    fontSize = 16.sp
+                )
+                Text("${detail.maxHeartRate}", color = Color.White, fontSize = 14.sp)
+            }
         }
     }
 }

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -184,4 +184,9 @@
     <string name="sync_success">Data sync successful</string>
     <string name="sync_success_with_type">%1$s data sync successful</string>
 
+    <string name="date_label">Date</string>
+    <string name="time_label">Time</string>
+    <string name="duration_label">Duration</string>
+    <string name="minutes_short">min</string>
+
 </resources>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -200,4 +200,8 @@
     <string name="min_hr">Min HR</string>
     <string name="max_hr">Max HR</string>
     <string name="duration_minutes">Duration: %1$d min</string>
+    <string name="date_label">Date</string>
+    <string name="time_label">Time</string>
+    <string name="duration_label">Duration</string>
+    <string name="minutes_short">min</string>
 </resources>


### PR DESCRIPTION
## Summary
- separate labels and values in `ExerciseDetailItem` and align values vertically within the card
- enlarge activity name font and use larger fonts for labels than values
- add string resources for new labels

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2a43b75c832fa8c732e5d90d9038