### PR TITLE
feat: enhance weekly progress screen

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ExerciseDetailBottomSheet.kt
@@ -140,7 +140,11 @@ private fun ExerciseDetailItem(detail: ExerciseDetailUi) {
                     color = Color.LightGray,
                     fontSize = 16.sp
                 )
-                Text("${detail.calories}", color = Color.White, fontSize = 14.sp)
+                Text(
+                    "${detail.calories} ${stringResource(id = R.string.kcal_unit)}",
+                    color = Color.White,
+                    fontSize = 14.sp
+                )
             }
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -152,7 +156,11 @@ private fun ExerciseDetailItem(detail: ExerciseDetailUi) {
                     color = Color.LightGray,
                     fontSize = 16.sp
                 )
-                Text("${detail.minHeartRate}", color = Color.White, fontSize = 14.sp)
+                Text(
+                    "${detail.minHeartRate} ${stringResource(id = R.string.bpm_unit)}",
+                    color = Color.White,
+                    fontSize = 14.sp
+                )
             }
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -164,7 +172,11 @@ private fun ExerciseDetailItem(detail: ExerciseDetailUi) {
                     color = Color.LightGray,
                     fontSize = 16.sp
                 )
-                Text("${detail.maxHeartRate}", color = Color.White, fontSize = 14.sp)
+                Text(
+                    "${detail.maxHeartRate} ${stringResource(id = R.string.bpm_unit)}",
+                    color = Color.White,
+                    fontSize = 14.sp
+                )
             }
         }
     }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
@@ -59,6 +59,12 @@ class WeeklyProgressViewModel @Inject constructor(
     private val _resistanceMinutes = MutableStateFlow(0)
     val resistanceMinutes: StateFlow<Int> = _resistanceMinutes
 
+    private val _activityCalories = MutableStateFlow(0)
+    val activityCalories: StateFlow<Int> = _activityCalories
+
+    private val _resistanceCalories = MutableStateFlow(0)
+    val resistanceCalories: StateFlow<Int> = _resistanceCalories
+
     private val _activityProgressPercent = MutableStateFlow(0)
     val activityProgressPercent: StateFlow<Int> = _activityProgressPercent
 
@@ -79,6 +85,9 @@ class WeeklyProgressViewModel @Inject constructor(
 
     private val _resistanceDetails = MutableStateFlow<List<ExerciseDetailUi>>(emptyList())
     val resistanceDetails: StateFlow<List<ExerciseDetailUi>> = _resistanceDetails
+
+    private val _daysWithExercise = MutableStateFlow<Set<LocalDate>>(emptySet())
+    val daysWithExercise: StateFlow<Set<LocalDate>> = _daysWithExercise
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -132,14 +141,22 @@ class WeeklyProgressViewModel @Inject constructor(
                 val minutes = TimeUnit.MILLISECONDS.toMinutes(totalMillis).toInt()
                 _activityMinutes.value = minutes
 
+                _activityCalories.value = activityList.sumOf { it.calorie.toInt() }
+
                 val resistanceMillis = resistanceList.sumOf { it.endTime - it.startTime }
                 val resistanceMinutes = TimeUnit.MILLISECONDS.toMinutes(resistanceMillis).toInt()
                 _resistanceMinutes.value = resistanceMinutes
+
+                _resistanceCalories.value = resistanceList.sumOf { it.calorie.toInt() }
 
                 _activityProgressPercent.value =
                     ((minutes * 100f) / ACTIVITY_GOAL_MINUTES).coerceAtMost(100f).toInt()
                 _resistanceProgressPercent.value =
                     ((resistanceMinutes * 100f) / ACTIVITY_GOAL_MINUTES).coerceAtMost(100f).toInt()
+
+                _daysWithExercise.value = weekList.map {
+                    Instant.ofEpochMilli(it.startTime).atZone(ZoneId.systemDefault()).toLocalDate()
+                }.toSet()
 
                 _hasData.value = weekList.isNotEmpty()
             }

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -188,5 +188,9 @@
     <string name="time_label">Time</string>
     <string name="duration_label">Duration</string>
     <string name="minutes_short">min</string>
+    <string name="show_details">Show Details</string>
+    <string name="kcal_unit">Kcal</string>
+    <string name="bpm_unit">BPM</string>
+    <string name="exercises_on_date">Exercises on %1$s</string>
 
 </resources>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -204,4 +204,8 @@
     <string name="time_label">Time</string>
     <string name="duration_label">Duration</string>
     <string name="minutes_short">min</string>
+    <string name="show_details">Show Details</string>
+    <string name="kcal_unit">Kcal</string>
+    <string name="bpm_unit">BPM</string>
+    <string name="exercises_on_date">Exercises on %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- show weekly calories and details button in progress cards
- mark exercise days and allow day-specific filtering
- add units for calories and heart rate in exercise details

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b322c01d8832f81f76c2356a80651