### PR TITLE
Show toast on sync and update dashboard icon

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -1,5 +1,6 @@
 package researchstack.presentation.screen.main
 
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,7 +22,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Notifications
@@ -38,16 +38,17 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -134,8 +135,8 @@ fun DashboardScreen(
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
-                        Icons.Default.AccountBalance,
-                        contentDescription = stringResource(id = R.string.bank),
+                        painter = painterResource(id = R.drawable.fixed_biceps),
+                        contentDescription = stringResource(id = R.string.home),
                         tint = Color.Black,
                         modifier = Modifier.size(22.dp)
                     )
@@ -146,6 +147,11 @@ fun DashboardScreen(
                 ) {
                     IconButton(onClick = {
                         permissionsLauncher.launch(healthConnectPermissionViewModel.permissions)
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.sync_request_submitted),
+                            Toast.LENGTH_SHORT
+                        ).show()
                     }) {
                         Icon(
                             Icons.Default.Sync,

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -166,6 +166,7 @@
     <string name="close">Close</string>
     <string name="sync">Sync</string>
     <string name="sync_now">Sync Now</string>
+    <string name="sync_request_submitted">Sync request has been submitted successfully</string>
   <string name="activity_tab">Activity</string>
   <string name="notifications">Notifications</string>
   <string name="weekly_progress">Weekly Progress</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
     <string name="close">Close</string>
     <string name="sync">Sync</string>
     <string name="sync_now">Sync Now</string>
+    <string name="sync_request_submitted">Sync request has been submitted successfully</string>
     <string name="activity_tab">Activity</string>
     <string name="notifications">Notifications</string>
     <string name="weekly_progress">Weekly Progress</string>


### PR DESCRIPTION
## Summary
- Show confirmation toast when requesting data sync
- Replace top left dashboard icon with `fixed_biceps` drawable

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b40a555d8832fab683fb44bab7278