### PR TITLE
feat: navigate to weekly progress from summary card

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/component/CommonCard.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/component/CommonCard.kt
@@ -20,9 +20,11 @@ fun ComplianceSummaryCard(
     color: Color,
     title: String,
     stats: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
 ) {
     Card(
+        onClick = onClick,
         modifier = modifier
             .fillMaxWidth(),
         colors = CardDefaults.cardColors(color),

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -211,13 +211,15 @@ fun DashboardScreen(
                                     color = Color(0xFF2B9179),
                                     title = stringResource(id = R.string.activity),
                                     stats = activityDurationDisplay,
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { navController.navigate(Route.WeeklyProgress.name) }
                                 )
                                 ComplianceSummaryCard(
                                     color = Color(0xFF287CC3),
                                     title = stringResource(id = R.string.resistance),
                                     stats = resistanceDurationDisplay,
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { navController.navigate(Route.WeeklyProgress.name) }
                                 )
                             }
                             Spacer(Modifier.height(12.dp))
@@ -229,13 +231,15 @@ fun DashboardScreen(
                                     color = Color(0xFF6C43CD),
                                     title = stringResource(id = R.string.weight),
                                     stats = stringResource(id = R.string.lbs),
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { navController.navigate(Route.WeeklyProgress.name) }
                                 )
                                 ComplianceSummaryCard(
                                     color = Color(0xFFAB369F),
                                     title = stringResource(id = R.string.bia),
                                     stats = "0%",
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { navController.navigate(Route.WeeklyProgress.name) }
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- make `ComplianceSummaryCard` clickable with an `onClick` callback
- navigate to WeeklyProgress when a summary card is tapped on the dashboard

## Testing
- `./gradlew :samples:starter-mobile-app:test` *(fails: could not determine dependencies; missing Android SDK packages and licenses)*

------
https://chatgpt.com/codex/tasks/task_e_688b48580a10832f8c97c5dfe21f2ad7