### PR TITLE
Check permissions before syncing exercises

### DIFF
--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -167,7 +167,9 @@
     <string name="sync">Sync</string>
     <string name="sync_now">Sync Now</string>
     <string name="sync_request_submitted">Sync request has been submitted successfully</string>
-  <string name="activity_tab">Activity</string>
+    <string name="exercise_permission_required">Exercise read permissions are required to sync.</string>
+    <string name="background_permission_required">Background health data permission is required to sync.</string>
+    <string name="activity_tab">Activity</string>
   <string name="notifications">Notifications</string>
   <string name="weekly_progress">Weekly Progress</string>
   <string name="mark_as_read">Mark as read</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -182,6 +182,8 @@
     <string name="sync">Sync</string>
     <string name="sync_now">Sync Now</string>
     <string name="sync_request_submitted">Sync request has been submitted successfully</string>
+    <string name="exercise_permission_required">Exercise read permissions are required to sync.</string>
+    <string name="background_permission_required">Background health data permission is required to sync.</string>
     <string name="activity_tab">Activity</string>
     <string name="notifications">Notifications</string>
     <string name="weekly_progress">Weekly Progress</string>


### PR DESCRIPTION
## Summary
- Check both exercise read and background permissions before starting sync
- Surface which permissions are missing and request them when needed
- Add user-facing strings for missing permission messages

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b52d3766c832fb743971b24f85d76