### PR TITLE
feat: add swipe hint to weekly progress

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
@@ -203,6 +203,7 @@ fun WeeklyProgressScreen(
                     )
                 }
             }
+            SwipeHint()
             Spacer(Modifier.height(16.dp))
             Row(
                 modifier = Modifier
@@ -300,6 +301,36 @@ fun WeeklyProgressScreen(
             }
             Spacer(Modifier.height(24.dp))
         }
+    }
+}
+
+@Composable
+private fun SwipeHint() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = null,
+            tint = Color.LightGray,
+            modifier = Modifier.size(16.dp)
+        )
+        Text(
+            text = stringResource(id = R.string.swipe_to_change_week),
+            color = Color.LightGray,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(horizontal = 4.dp)
+        )
+        Icon(
+            Icons.AutoMirrored.Filled.ArrowForwardIos,
+            contentDescription = null,
+            tint = Color.LightGray,
+            modifier = Modifier.size(16.dp)
+        )
     }
 }
 

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -172,6 +172,7 @@
     <string name="activity_tab">Activity</string>
   <string name="notifications">Notifications</string>
   <string name="weekly_progress">Weekly Progress</string>
+  <string name="swipe_to_change_week">Swipe left or right to change week</string>
   <string name="mark_as_read">Mark as read</string>
     <string name="enable_notifications">Enable notifications</string>
     <string name="enable_dark_mode">Enable dark mode</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="activity_tab">Activity</string>
     <string name="notifications">Notifications</string>
     <string name="weekly_progress">Weekly Progress</string>
+    <string name="swipe_to_change_week">Swipe left or right to change week</string>
     <string name="mark_as_read">Mark as read</string>
     <string name="enable_notifications">Enable notifications</string>
     <string name="enable_dark_mode">Enable dark mode</string>


### PR DESCRIPTION
## Summary
- show visual swipe hint on WeeklyProgressScreen
- add localized string for swipe hint

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: command terminated after Gradle setup)*

------
https://chatgpt.com/codex/tasks/task_e_688b58d441e8832fa5a0fa0dad4e75be