### PR TITLE
Add detailed logging to health data sync

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
@@ -45,14 +45,20 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
     private val grpcHealthDataSynchronizer: GrpcHealthDataSynchronizer<HealthDataModel>
 ) : HealthConnectDataSyncRepository {
     override suspend fun syncHealthData() {
+        AppLogger.saveLog(DataSyncLog("start syncHealthData"))
         getProfileUseCase().onSuccess { profile ->
+            AppLogger.saveLog(DataSyncLog("profile loaded ${'$'}{profile.id}"))
             getRequiredHealthDataTypes().forEach { dataType ->
+                AppLogger.saveLog(DataSyncLog("start sync for ${'$'}{dataType.name}"))
                 val result: List<TimestampMapData>? = when (dataType) {
                     SHealthDataType.EXERCISE -> {
 
                         val exerciseRecords = healthConnectDataSource.getData(
                             ExerciseSessionRecord::class
                         ).filterIsInstance<ExerciseSessionRecord>()
+                        AppLogger.saveLog(
+                            DataSyncLog("fetched ${'$'}{exerciseRecords.size} exercise records")
+                        )
 
                         val studyId = studyRepository.getActiveStudies().first().firstOrNull()?.id ?: ""
                         val enrollmentMillis = enrollmentDatePref.getEnrollmentDate(studyId)?.let { dateString ->
@@ -64,25 +70,52 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
 
                         val items = mutableListOf<Exercise>()
                         exerciseRecords.forEach { record ->
+                            AppLogger.saveLog(
+                                DataSyncLog("processing exercise ${'$'}{record.metadata.id}")
+                            )
                             val recordStartTime = record.startTime.toEpochMilli()
                             if (enrollmentMillis != null && recordStartTime < enrollmentMillis) {
                                 Log.d(TAG, "Ignore exercise ${'$'}{record.metadata.id} before enrollment date")
+                                AppLogger.saveLog(
+                                    DataSyncLog("ignore exercise ${'$'}{record.metadata.id} before enrollment")
+                                )
                             } else {
                                 val sessionData = healthConnectDataSource.getAggregateData(record.metadata.id)
                                 val exercise = processExerciseData(record, sessionData, studyId, enrollmentDatePref)
                                 items.add(exercise)
+                                AppLogger.saveLog(
+                                    DataSyncLog("prepared exercise ${'$'}{record.metadata.id}")
+                                )
                             }
                         }
                         exerciseDao.insertAll(*items.toTypedArray())
+                        AppLogger.saveLog(
+                            DataSyncLog("stored ${'$'}{items.size} exercise records in db")
+                        )
                         items
                     }
 
                     else -> null
                 }
                 result?.let {
-                    uploadDataToServer(dataType, it)
+                    if (it.isEmpty()) {
+                        Log.d(TAG, "No data to sync for ${'$'}{dataType.name}")
+                        AppLogger.saveLog(
+                            DataSyncLog("nothing to sync for ${'$'}{dataType.name}")
+                        )
+                    } else {
+                        AppLogger.saveLog(
+                            DataSyncLog("upload ${'$'}{it.size} records for ${'$'}{dataType.name}")
+                        )
+                        uploadDataToServer(dataType, it)
+                    }
                 }
             }
+        }.onFailure {
+            Log.e(TAG, "fail to load profile", it)
+            AppLogger.saveLog(
+                DataSyncLog("FAIL: load profile ${'$'}{it.stackTraceToString()}")
+            )
         }
 
 //        getRequiredHealthDataTypes().forEach { dataType ->
@@ -144,19 +177,31 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
         dataType: SHealthDataType,
         result: List<TimestampMapData>
     ) {
+        AppLogger.saveLog(
+            DataSyncLog("uploadDataToServer start ${dataType.name} ${result.size}")
+        )
         val healthDataModel = toHealthDataModel(dataType, result)
-        studyRepository.getActiveStudies().first().filter {
+        val approvedStudies = studyRepository.getActiveStudies().first().filter {
             shareAgreementRepository.getApprovalShareAgreementWithStudyAndDataType(
                 it.id,
                 dataType.name
             )
-        }.forEach { study ->
+        }
+        AppLogger.saveLog(
+            DataSyncLog("approved studies ${approvedStudies.size} for ${dataType.name}")
+        )
+        approvedStudies.forEach { study ->
+            AppLogger.saveLog(
+                DataSyncLog("upload to study ${'$'}{study.id} ${dataType.name}")
+            )
             grpcHealthDataSynchronizer.syncHealthData(
                 listOf(study.id),
                 healthDataModel
             ).onSuccess {
                 Log.i(TAG, "success to upload data: $dataType")
-                AppLogger.saveLog(DataSyncLog("sync $dataType ${result.size}"))
+                AppLogger.saveLog(
+                    DataSyncLog("sync $dataType ${result.size} for ${'$'}{study.id}")
+                )
                 NotificationUtil.initialize(context)
                 val dataTypeName = context.getString(dataType.toStringResourceId())
                 val message = context.getString(R.string.sync_success_with_type, dataTypeName)
@@ -170,7 +215,11 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
             }.onFailure {
                 Log.e(TAG, "fail to upload data to server")
                 Log.e(TAG, it.stackTraceToString())
-                AppLogger.saveLog(DataSyncLog("FAIL: sync data $dataType ${it.stackTraceToString()}"))
+                AppLogger.saveLog(
+                    DataSyncLog(
+                        "FAIL: sync data $dataType for ${'$'}{study.id} ${'$'}{it.stackTraceToString()}"
+                    )
+                )
             }.getOrThrow()
         }
     }
@@ -179,12 +228,30 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
         return HealthDataModel(dataType, data.map { it.toDataMap() })
     }
 
-    private suspend fun getRequiredHealthDataTypes(): Set<SHealthDataType> =
-        studyDao.getActiveStudies().first().flatMap { (id) ->
-            shareAgreementDao.getAgreedShareAgreement(id).first().map {
-                runCatching { SHealthDataType.valueOf(it.dataType) }.getOrNull()
-            }.filterIsInstance<SHealthDataType>()
+    private suspend fun getRequiredHealthDataTypes(): Set<SHealthDataType> {
+        AppLogger.saveLog(DataSyncLog("start getRequiredHealthDataTypes"))
+        val activeStudies = studyDao.getActiveStudies().first()
+        AppLogger.saveLog(DataSyncLog("active studies ${activeStudies.size}"))
+        val types = activeStudies.flatMap { (id) ->
+            AppLogger.saveLog(DataSyncLog("load agreements for ${'$'}id"))
+            shareAgreementDao.getAgreedShareAgreement(id).first().map { agreement ->
+                runCatching { SHealthDataType.valueOf(agreement.dataType) }
+                    .onSuccess { type ->
+                        AppLogger.saveLog(
+                            DataSyncLog("study ${'$'}id requires ${'$'}type")
+                        )
+                    }
+                    .onFailure {
+                        AppLogger.saveLog(
+                            DataSyncLog("unknown data type ${'$'}{agreement.dataType}")
+                        )
+                    }
+                    .getOrNull()
+            }.filterNotNull()
         }.toSet()
+        AppLogger.saveLog(DataSyncLog("required types ${'$'}{types.joinToString()}"))
+        return types
+    }
 
     companion object {
         private val TAG = HealthConnectDataSyncRepositoryImpl::class.simpleName


### PR DESCRIPTION
## Summary
- add AppLogger tracking for exercise sync workflow
- log required data types and per-study uploads

## Testing
- `./gradlew :samples:starter-mobile-app:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b96a94e38832fb80c309280025d4d