### PR TITLE
feat: add log export sharing

### DIFF
--- a/samples/starter-mobile-app/src/main/AndroidManifest.xml
+++ b/samples/starter-mobile-app/src/main/AndroidManifest.xml
@@ -131,6 +131,16 @@
       android:process=":bound_service" />
 
     <provider
+      android:name="androidx.core.content.FileProvider"
+      android:authorities="${applicationId}.fileprovider"
+      android:exported="false"
+      android:grantUriPermissions="true">
+      <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/file_paths" />
+    </provider>
+
+    <provider
       android:name="androidx.startup.InitializationProvider"
       android:authorities="${applicationId}.androidx-startup"
       android:exported="false"

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/log/LogScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/log/LogScreen.kt
@@ -11,15 +11,20 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import researchstack.presentation.component.TopBar
 import researchstack.presentation.theme.AppTheme
 import researchstack.presentation.viewmodel.log.AppLogViewModel
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
 
 @Composable
 fun LogScreen(
@@ -30,7 +35,36 @@ fun LogScreen(
     Scaffold(
         modifier = Modifier.fillMaxSize(1f),
         topBar = {
+            val context = LocalContext.current
             TopBar(title = "Logs") {
+                IconButton(onClick = {
+                    val logText = buildString {
+                        logs.forEach { log ->
+                            val time = log.getData()["time"]
+                            val message = log.getData()["message"]
+                            append("$time: $message\n")
+                        }
+                    }
+                    val file = File(context.cacheDir, "logs_${System.currentTimeMillis()}.txt")
+                    file.writeText(logText)
+                    val uri = FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        file
+                    )
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_STREAM, uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                    context.startActivity(Intent.createChooser(shareIntent, "Share logs"))
+                }) {
+                    Icon(
+                        imageVector = Icons.Default.Share,
+                        contentDescription = "share",
+                        tint = AppTheme.colors.onSurface,
+                    )
+                }
                 IconButton(onClick = {
                     appLogViewModel.refresh()
                 }) {

--- a/samples/starter-mobile-app/src/main/res/xml/file_paths.xml
+++ b/samples/starter-mobile-app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="logs" path="." />
+</paths>


### PR DESCRIPTION
## Summary
- allow export logs to a text file and share
- register FileProvider for sharing cache files

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_688b9f81f150832fa500f780d490f9e3