### PR TITLE
feat: show weekly bia measurement count

### DIFF
--- a/common/src/main/kotlin/researchstack/data/local/room/dao/BiaDao.kt
+++ b/common/src/main/kotlin/researchstack/data/local/room/dao/BiaDao.kt
@@ -1,8 +1,14 @@
 package researchstack.data.local.room.dao
 
 import androidx.room.Dao
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 import researchstack.domain.model.priv.BIA_TABLE_NAME
 import researchstack.domain.model.priv.Bia
 
 @Dao
-abstract class BiaDao : PrivDao<Bia>(BIA_TABLE_NAME)
+abstract class BiaDao : PrivDao<Bia>(BIA_TABLE_NAME) {
+
+    @Query("SELECT COUNT(*) FROM $BIA_TABLE_NAME WHERE timestamp BETWEEN :start AND :end")
+    abstract fun countBetween(start: Long, end: Long): Flow<Int>
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/DaoProvider.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/DaoProvider.kt
@@ -19,6 +19,7 @@ import researchstack.data.datasource.local.room.dao.StudyDao
 import researchstack.data.datasource.local.room.dao.TaskDao
 import researchstack.data.datasource.local.room.dao.ExerciseDao
 import researchstack.data.local.room.WearableAppDataBase
+import researchstack.data.local.room.dao.BiaDao
 import researchstack.data.local.room.dao.PassiveDataStatusDao
 import javax.inject.Singleton
 
@@ -97,4 +98,9 @@ object DaoProvider {
     fun provideWearablePassiveDataStatusDao(
         @ApplicationContext context: Context
     ): PassiveDataStatusDao = WearableAppDataBase.getDatabase(context).passiveDataStatusDao()
+
+    @Singleton
+    @Provides
+    fun provideBiaDao(@ApplicationContext context: Context): BiaDao =
+        WearableAppDataBase.getDatabase(context).biaDao()
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -86,6 +86,8 @@ fun DashboardScreen(
     val resistanceDuration by dashboardViewModel.resistanceDurationMinutes.collectAsState()
     val activityProgressPercent by dashboardViewModel.activityProgressPercent.collectAsState()
     val resistanceProgressPercent by dashboardViewModel.resistanceProgressPercent.collectAsState()
+    val biaCount by dashboardViewModel.biaCount.collectAsState()
+    val biaProgressPercent by dashboardViewModel.biaProgressPercent.collectAsState()
     val weekStart by dashboardViewModel.weekStart.collectAsState()
     val rangeFormatter = DateTimeFormatter.ofPattern("MMM d")
 
@@ -279,7 +281,7 @@ fun DashboardScreen(
                                 ComplianceSummaryCard(
                                     color = Color(0xFFAB369F),
                                     title = stringResource(id = R.string.bia),
-                                    stats = "0%",
+                                    stats = biaCount.toString(),
                                     modifier = Modifier.weight(1f),
                                     onClick = { navController.navigate(Route.WeeklyProgress.name) }
                                 )
@@ -340,7 +342,7 @@ fun DashboardScreen(
                                 )
                                 ProgressBarItem(
                                     stringResource(id = R.string.bia),
-                                    0,
+                                    biaProgressPercent,
                                     Color(0xFFFFA500)
                                 )
                             }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -274,7 +274,7 @@ fun DashboardScreen(
                                 ComplianceSummaryCard(
                                     color = Color(0xFF6C43CD),
                                     title = stringResource(id = R.string.weight),
-                                    stats = stringResource(id = R.string.lbs),
+                                    stats = biaCount.toString(),
                                     modifier = Modifier.weight(1f),
                                     onClick = { navController.navigate(Route.WeeklyProgress.name) }
                                 )
@@ -337,7 +337,7 @@ fun DashboardScreen(
                                 )
                                 ProgressBarItem(
                                     stringResource(id = R.string.weight),
-                                    0,
+                                    biaProgressPercent,
                                     Color(0xFFFF6347)
                                 )
                                 ProgressBarItem(

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import researchstack.data.datasource.local.pref.EnrollmentDatePref
 import researchstack.data.datasource.local.pref.dataStore
 import researchstack.data.datasource.local.room.dao.ExerciseDao
+import researchstack.data.local.room.dao.BiaDao
 import researchstack.domain.model.healthConnect.Exercise
 import researchstack.domain.repository.StudyRepository
 import java.time.LocalDate
@@ -26,10 +27,12 @@ class DashboardViewModel @Inject constructor(
     application: Application,
     private val studyRepository: StudyRepository,
     private val exerciseDao: ExerciseDao,
+    private val biaDao: BiaDao,
 ) : AndroidViewModel(application) {
 
     companion object {
         const val ACTIVITY_GOAL_MINUTES = 150
+        const val BIA_GOAL_PER_WEEK = 7
     }
 
     private val enrollmentDatePref = EnrollmentDatePref(application.dataStore)
@@ -55,6 +58,12 @@ class DashboardViewModel @Inject constructor(
     private val _weekStart = MutableStateFlow(LocalDate.now())
     val weekStart: StateFlow<LocalDate> = _weekStart
 
+    private val _biaCount = MutableStateFlow(0)
+    val biaCount: StateFlow<Int> = _biaCount
+
+    private val _biaProgressPercent = MutableStateFlow(0)
+    val biaProgressPercent: StateFlow<Int> = _biaProgressPercent
+
     init {
         refreshData()
     }
@@ -68,6 +77,16 @@ class DashboardViewModel @Inject constructor(
                     val weekStart = calculateCurrentWeekStart(LocalDate.parse(dateString))
                     _weekStart.value = weekStart
                     val startMillis = weekStart.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                    val endMillis = startMillis + TimeUnit.DAYS.toMillis(7)
+
+                    launch {
+                        biaDao.countBetween(startMillis, endMillis).collect { count ->
+                            _biaCount.value = count
+                            val progress = ((count * 100f) / BIA_GOAL_PER_WEEK).coerceAtMost(100f)
+                            _biaProgressPercent.value = progress.toInt()
+                        }
+                    }
+
                     exerciseDao.getExercisesFrom(startMillis).collect { list ->
                         val resistanceList = list.filter { isResistance(it.exerciseType.toInt()) }
                         val exerciseList = list.filterNot { isResistance(it.exerciseType.toInt()) }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
@@ -32,7 +32,6 @@ class DashboardViewModel @Inject constructor(
 
     companion object {
         const val ACTIVITY_GOAL_MINUTES = 150
-        const val BIA_GOAL_PER_WEEK = 7
     }
 
     private val enrollmentDatePref = EnrollmentDatePref(application.dataStore)
@@ -82,8 +81,8 @@ class DashboardViewModel @Inject constructor(
                     launch {
                         biaDao.countBetween(startMillis, endMillis).collect { count ->
                             _biaCount.value = count
-                            val progress = ((count * 100f) / BIA_GOAL_PER_WEEK).coerceAtMost(100f)
-                            _biaProgressPercent.value = progress.toInt()
+                            val progress = if (count > 0) 100 else 0
+                            _biaProgressPercent.value = progress
                         }
                     }
 


### PR DESCRIPTION
## Summary
- add Room query to count weekly BIA records
- expose BiaDao through Hilt
- display BIA measurement totals and progress on dashboard

## Testing
- `./gradlew :common:test :samples:starter-mobile-app:test` *(fails: Could not determine the dependencies of task ':common:testDebugUnitTest'. Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_688cf1c14828832fae575944e8e06289