### PR TITLE
feat: track weekly weight progress

### DIFF
--- a/common/src/main/kotlin/researchstack/data/local/room/dao/UserProfileDao.kt
+++ b/common/src/main/kotlin/researchstack/data/local/room/dao/UserProfileDao.kt
@@ -11,4 +11,7 @@ abstract class UserProfileDao : PrivDao<UserProfile>(USER_PROFILE_TABLE_NAME) {
 
     @Query("SELECT * FROM user_profile ORDER BY timestamp DESC LIMIT 1")
     abstract fun getLatest(): Flow<UserProfile?>
+
+    @Query("SELECT COUNT(*) FROM $USER_PROFILE_TABLE_NAME WHERE timestamp BETWEEN :start AND :end")
+    abstract fun countBetween(start: Long, end: Long): Flow<Int>
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -89,6 +89,7 @@ fun DashboardScreen(
     val biaCount by dashboardViewModel.biaCount.collectAsState()
     val weight by dashboardViewModel.weight.collectAsState()
     val biaProgressPercent by dashboardViewModel.biaProgressPercent.collectAsState()
+    val weightProgressPercent by dashboardViewModel.weightProgressPercent.collectAsState()
     val weekStart by dashboardViewModel.weekStart.collectAsState()
     val rangeFormatter = DateTimeFormatter.ofPattern("MMM d")
 
@@ -338,7 +339,7 @@ fun DashboardScreen(
                                 )
                                 ProgressBarItem(
                                     stringResource(id = R.string.weight),
-                                    biaProgressPercent,
+                                    weightProgressPercent,
                                     Color(0xFFFF6347)
                                 )
                                 ProgressBarItem(

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
@@ -67,6 +67,9 @@ class DashboardViewModel @Inject constructor(
     private val _biaProgressPercent = MutableStateFlow(0)
     val biaProgressPercent: StateFlow<Int> = _biaProgressPercent
 
+    private val _weightProgressPercent = MutableStateFlow(0)
+    val weightProgressPercent: StateFlow<Int> = _weightProgressPercent
+
     private val _weight = MutableStateFlow("--")
     val weight: StateFlow<String> = _weight
 
@@ -90,6 +93,12 @@ class DashboardViewModel @Inject constructor(
                             _biaCount.value = count
                             val progress = if (count > 0) 100 else 0
                             _biaProgressPercent.value = progress
+                        }
+                    }
+                    launch {
+                        userProfileDao.countBetween(startMillis, endMillis).collect { count ->
+                            val progress = if (count > 0) 100 else 0
+                            _weightProgressPercent.value = progress
                         }
                     }
                     viewModelScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- count user profile entries within a week
- show weight progress based on weekly weight entries

## Testing
- `./gradlew :common:test :samples:starter-mobile-app:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d23d60794832fad595d57ae1cc285