### PR TITLE
feat: add progress screen with health charts

### DIFF
--- a/samples/starter-mobile-app/build.gradle.kts
+++ b/samples/starter-mobile-app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation(AppDependencies.SIGNATURE)
     implementation("org.burnoutcrew.composereorderable:reorderable:0.9.6")
     implementation("androidx.compose.material3:material3:1.3.2")
+    implementation("com.patrykandpatrick.vico:compose-m3:2.1.3")
 
     // Room
     implementation(AppDependencies.roomLibs)

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
@@ -16,6 +16,7 @@ enum class Route {
     Intro,
     Notifications,
     WeeklyProgress,
+    Progress,
 }
 
 enum class MainPage {

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -11,6 +11,7 @@ import researchstack.presentation.screen.insight.StudyPermissionSettingScreen
 import researchstack.presentation.screen.insight.StudyStatusScreen
 import researchstack.presentation.screen.main.MainScreen
 import researchstack.presentation.screen.main.WeeklyProgressScreen
+import researchstack.presentation.screen.main.ProgressScreen
 import researchstack.presentation.screen.notification.NotificationScreen
 import researchstack.presentation.screen.study.EligibilityFailScreen
 import researchstack.presentation.screen.study.StudyCodeInputScreen
@@ -40,6 +41,9 @@ fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) 
         }
         composable(Route.WeeklyProgress.name) {
             WeeklyProgressScreen()
+        }
+        composable(Route.Progress.name) {
+            ProgressScreen()
         }
         composable(Route.Welcome.name) {
             WelcomeScreen()

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
@@ -1,0 +1,183 @@
+package researchstack.presentation.screen.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import researchstack.presentation.viewmodel.ProgressViewModel
+import researchstack.presentation.viewmodel.CaloriePoint
+import researchstack.presentation.LocalNavController
+import androidx.compose.ui.res.stringResource
+import com.patrykandpatrick.vico.compose.m3.Chart
+import com.patrykandpatrick.vico.compose.m3.axis.rememberBottomAxis
+import com.patrykandpatrick.vico.compose.m3.axis.rememberStartAxis
+import com.patrykandpatrick.vico.compose.m3.chart.line.lineChart
+import com.patrykandpatrick.vico.compose.m3.chart.line.rememberLineSpec
+import com.patrykandpatrick.vico.compose.m3.marker.rememberMarker
+import com.patrykandpatrick.vico.core.entry.ChartEntryModelProducer
+import com.patrykandpatrick.vico.core.entry.FloatEntry
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import researchstack.R
+import researchstack.domain.model.priv.Bia
+
+@Composable
+fun ProgressScreen(viewModel: ProgressViewModel = hiltViewModel()) {
+    val navController = LocalNavController.current
+    val calories by viewModel.caloriePoints.collectAsState()
+    val biaList by viewModel.biaEntries.collectAsState()
+    val scrollState = rememberScrollState()
+    val dateFormatter = DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault())
+
+    Scaffold(
+        containerColor = Color(0xFF222222),
+        topBar = {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black)
+                    .padding(8.dp)
+            ) {
+                IconButton(
+                    onClick = { navController.popBackStack() },
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = null,
+                        tint = Color.White
+                    )
+                }
+                Text(
+                    text = stringResource(id = R.string.insights),
+                    color = Color.White,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 20.sp,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .verticalScroll(scrollState)
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.calorie_burn_over_time),
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            CalorieChart(calories, dateFormatter)
+            Text(
+                text = stringResource(id = R.string.calories_unit_full),
+                color = Color.Gray,
+                fontSize = 12.sp,
+                modifier = Modifier.align(Alignment.End).padding(top = 4.dp)
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Text(
+                text = stringResource(id = R.string.bia_progress),
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            BiaChart(biaList, dateFormatter)
+        }
+    }
+}
+
+@Composable
+private fun CalorieChart(points: List<CaloriePoint>, formatter: DateTimeFormatter) {
+    val modelProducer = remember { ChartEntryModelProducer() }
+    val labels = points.map { it.date.format(formatter) }
+    LaunchedEffect(points) {
+        val entries = points.mapIndexed { index, p -> FloatEntry(index.toFloat(), p.calories.toFloat()) }
+        modelProducer.setEntries(entries)
+    }
+    Chart(
+        chart = lineChart(),
+        chartModelProducer = modelProducer,
+        startAxis = rememberStartAxis(valueFormatter = { value, _ -> value.toInt().toString() }),
+        bottomAxis = rememberBottomAxis(valueFormatter = { value, _ -> labels.getOrNull(value.toInt()) ?: "" }),
+        marker = rememberMarker(),
+    )
+}
+
+@Composable
+private fun BiaChart(list: List<Bia>, formatter: DateTimeFormatter) {
+    val modelProducer = remember { ChartEntryModelProducer() }
+    val labels = list.map { Instant.ofEpochMilli(it.timestamp).atZone(java.time.ZoneId.systemDefault()).toLocalDate().format(formatter) }
+    LaunchedEffect(list) {
+        val muscle = list.mapIndexed { index, b -> FloatEntry(index.toFloat(), b.skeletalMuscleMass) }
+        val fat = list.mapIndexed { index, b -> FloatEntry(index.toFloat(), b.bodyFatRatio * 100f) }
+        val water = list.mapIndexed { index, b -> FloatEntry(index.toFloat(), b.totalBodyWater) }
+        modelProducer.setEntries(listOf(muscle, fat, water))
+    }
+    Chart(
+        chart = lineChart(
+            lines = listOf(
+                rememberLineSpec(color = Color(0xFF4CAF50)),
+                rememberLineSpec(color = Color(0xFFF44336)),
+                rememberLineSpec(color = Color(0xFF03A9F4)),
+            )
+        ),
+        chartModelProducer = modelProducer,
+        startAxis = rememberStartAxis(valueFormatter = { value, _ -> value.toInt().toString() }),
+        bottomAxis = rememberBottomAxis(valueFormatter = { value, _ -> labels.getOrNull(value.toInt()) ?: "" }),
+        marker = rememberMarker(),
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(16.dp), verticalAlignment = Alignment.CenterVertically) {
+        LegendItem(Color(0xFF4CAF50), stringResource(id = R.string.skeletal_muscle_mass))
+        LegendItem(Color(0xFFF44336), stringResource(id = R.string.body_fat_percent))
+        LegendItem(Color(0xFF03A9F4), stringResource(id = R.string.total_body_water))
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            Modifier
+                .size(12.dp)
+                .background(color)
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(text = label, color = Color.White, fontSize = 12.sp)
+    }
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/ProgressViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/ProgressViewModel.kt
@@ -1,0 +1,50 @@
+package researchstack.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import androidx.lifecycle.viewModelScope
+import researchstack.data.datasource.local.room.dao.ExerciseDao
+import researchstack.data.local.room.dao.BiaDao
+import researchstack.domain.model.priv.Bia
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+data class CaloriePoint(val date: LocalDate, val calories: Double)
+
+@HiltViewModel
+class ProgressViewModel @Inject constructor(
+    private val exerciseDao: ExerciseDao,
+    private val biaDao: BiaDao,
+) : ViewModel() {
+
+    private val _caloriePoints = MutableStateFlow<List<CaloriePoint>>(emptyList())
+    val caloriePoints: StateFlow<List<CaloriePoint>> = _caloriePoints
+
+    private val _biaEntries = MutableStateFlow<List<Bia>>(emptyList())
+    val biaEntries: StateFlow<List<Bia>> = _biaEntries
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            exerciseDao.getExercisesFrom(0).collect { list ->
+                val zone = ZoneId.systemDefault()
+                val grouped = list.groupBy { Instant.ofEpochMilli(it.startTime).atZone(zone).toLocalDate() }
+                    .map { (date, entries) ->
+                        CaloriePoint(date, entries.sumOf { it.calorie })
+                    }
+                    .sortedBy { it.date }
+                _caloriePoints.value = grouped
+            }
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            biaDao.getBetween(0, Long.MAX_VALUE).collect { list ->
+                _biaEntries.value = list.sortedBy { it.timestamp }
+            }
+        }
+    }
+}

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -207,5 +207,9 @@
     <string name="body_fat_percent">Body Fat %</string>
     <string name="total_body_water">Total Body Water</string>
     <string name="bmr">BMR</string>
+    <string name="insights">Insights</string>
+    <string name="calorie_burn_over_time">Calorie Burn Over Time</string>
+    <string name="bia_progress">BIA Progress</string>
+    <string name="calories_unit_full">Calories (Kcal)</string>
 
 </resources>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -225,4 +225,8 @@
     <string name="body_fat_percent">Body Fat %</string>
     <string name="total_body_water">Total Body Water</string>
     <string name="bmr">BMR</string>
+    <string name="insights">Insights</string>
+    <string name="calorie_burn_over_time">Calorie Burn Over Time</string>
+    <string name="bia_progress">BIA Progress</string>
+    <string name="calories_unit_full">Calories (Kcal)</string>
 </resources>


### PR DESCRIPTION
## Summary
- add ProgressScreen with calorie and BIA line charts
- implement ProgressViewModel to stream all exercise and BIA data
- wire navigation route and include Vico chart dependency

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e4d2b858832fa9cbb34be2e3475a