### PR TITLE
feat: add progress screen with charts

### DIFF
--- a/samples/starter-mobile-app/build.gradle.kts
+++ b/samples/starter-mobile-app/build.gradle.kts
@@ -142,6 +142,8 @@ dependencies {
     implementation(AppDependencies.SIGNATURE)
     implementation("org.burnoutcrew.composereorderable:reorderable:0.9.6")
     implementation("androidx.compose.material3:material3:1.3.2")
+    implementation("com.patrykandpatrick.vico:compose-m3:1.16.0")
+    implementation("com.patrykandpatrick.vico:core:1.16.0")
 
     // Room
     implementation(AppDependencies.roomLibs)

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
@@ -15,6 +15,7 @@ enum class Route {
     Login,
     Intro,
     Notifications,
+    Progress,
     WeeklyProgress,
 }
 

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -10,6 +10,7 @@ import researchstack.presentation.screen.insight.SettingScreen
 import researchstack.presentation.screen.insight.StudyPermissionSettingScreen
 import researchstack.presentation.screen.insight.StudyStatusScreen
 import researchstack.presentation.screen.main.MainScreen
+import researchstack.presentation.screen.main.ProgressScreen
 import researchstack.presentation.screen.main.WeeklyProgressScreen
 import researchstack.presentation.screen.notification.NotificationScreen
 import researchstack.presentation.screen.study.EligibilityFailScreen
@@ -37,6 +38,9 @@ fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) 
         }
         composable(Route.Notifications.name) {
             NotificationScreen()
+        }
+        composable(Route.Progress.name) {
+            ProgressScreen()
         }
         composable(Route.WeeklyProgress.name) {
             WeeklyProgressScreen()

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
@@ -30,12 +30,13 @@ import com.patrykandpatrick.vico.compose.chart.line.lineSpec
 import com.patrykandpatrick.vico.compose.component.lineComponent
 import com.patrykandpatrick.vico.compose.component.marker.markerComponent
 import com.patrykandpatrick.vico.compose.component.shapeComponent
+import com.patrykandpatrick.vico.compose.component.textComponent
 import com.patrykandpatrick.vico.core.axis.AxisPosition
 import com.patrykandpatrick.vico.core.axis.formatter.AxisValueFormatter
-import com.patrykandpatrick.vico.core.component.marker.Marker
 import com.patrykandpatrick.vico.core.entry.ChartEntryModelProducer
 import com.patrykandpatrick.vico.core.entry.entryOf
 import com.patrykandpatrick.vico.core.component.shape.Shapes
+import com.patrykandpatrick.vico.core.marker.Marker
 import researchstack.R
 import researchstack.domain.model.priv.Bia
 import researchstack.presentation.LocalNavController
@@ -170,11 +171,11 @@ private fun LegendItem(color: Color, label: String) {
 
 @Composable
 private fun rememberSimpleMarker(): Marker {
-    val label = com.patrykandpatrick.vico.compose.component.textComponent(
+    val label = textComponent(
         color = Color.White,
         background = shapeComponent(Shapes.pillShape, Color.DarkGray)
     )
     val indicator = shapeComponent(Shapes.pillShape, Color.White)
     val guideline = lineComponent(Color.White.copy(alpha = 0.2f), 2.dp)
-    return remember { markerComponent(label = label, indicator = indicator, guideline = guideline) }
+    return markerComponent(label = label, indicator = indicator, guideline = guideline)
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
@@ -1,0 +1,180 @@
+package researchstack.presentation.screen.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.patrykandpatrick.vico.compose.axis.horizontal.rememberBottomAxis
+import com.patrykandpatrick.vico.compose.axis.vertical.rememberStartAxis
+import com.patrykandpatrick.vico.compose.chart.Chart
+import com.patrykandpatrick.vico.compose.chart.line.lineChart
+import com.patrykandpatrick.vico.compose.chart.line.lineSpec
+import com.patrykandpatrick.vico.compose.component.lineComponent
+import com.patrykandpatrick.vico.compose.component.marker.markerComponent
+import com.patrykandpatrick.vico.compose.component.shapeComponent
+import com.patrykandpatrick.vico.core.axis.AxisPosition
+import com.patrykandpatrick.vico.core.axis.formatter.AxisValueFormatter
+import com.patrykandpatrick.vico.core.component.marker.Marker
+import com.patrykandpatrick.vico.core.entry.ChartEntryModelProducer
+import com.patrykandpatrick.vico.core.entry.entryOf
+import com.patrykandpatrick.vico.core.component.shape.Shapes
+import researchstack.R
+import researchstack.domain.model.priv.Bia
+import researchstack.presentation.LocalNavController
+import researchstack.presentation.viewmodel.ProgressViewModel
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Composable
+fun ProgressScreen(viewModel: ProgressViewModel = hiltViewModel()) {
+    val navController = LocalNavController.current
+    val calories = viewModel.caloriesByDate.collectAsState().value
+    val bia = viewModel.biaEntries.collectAsState().value
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        containerColor = Color(0xFF222222),
+        topBar = {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black)
+                    .padding(8.dp)
+            ) {
+                IconButton(onClick = { navController.popBackStack() }, modifier = Modifier.align(Alignment.CenterStart)) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = Color.White)
+                }
+                Text(
+                    text = stringResource(id = R.string.insights),
+                    color = Color.White,
+                    fontSize = 20.sp,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            Text(text = stringResource(id = R.string.calorie_burn_over_time), color = Color.White, fontSize = 18.sp)
+            Spacer(Modifier.height(8.dp))
+            CalorieChart(calories)
+            Spacer(Modifier.height(24.dp))
+            Text(text = stringResource(id = R.string.bia_progress), color = Color.White, fontSize = 18.sp)
+            Spacer(Modifier.height(8.dp))
+            BiaChart(bia)
+        }
+    }
+}
+
+@Composable
+private fun CalorieChart(data: List<Pair<String, Float>>) {
+    if (data.isEmpty()) {
+        Text(text = stringResource(id = R.string.no_data_available), color = Color.White)
+        return
+    }
+    val modelProducer = remember { ChartEntryModelProducer() }
+    val marker = rememberSimpleMarker()
+    LaunchedEffect(data) {
+        modelProducer.setEntries(data.mapIndexed { index, pair -> entryOf(index.toFloat(), pair.second) })
+    }
+    val formatter = AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
+        data.getOrNull(value.toInt())?.first ?: ""
+    }
+    val lineColor = Color(0xFF64B5F6)
+    Chart(
+        chart = lineChart(lines = listOf(lineSpec(lineColor, point = shapeComponent(Shapes.pillShape, lineColor)))),
+        chartModelProducer = modelProducer,
+        startAxis = rememberStartAxis(title = stringResource(R.string.kcal_unit)),
+        bottomAxis = rememberBottomAxis(valueFormatter = formatter),
+        marker = marker,
+    )
+}
+
+@Composable
+private fun BiaChart(entries: List<Bia>) {
+    if (entries.isEmpty()) {
+        Text(text = stringResource(id = R.string.no_data_available), color = Color.White)
+        return
+    }
+    val modelProducer = remember { ChartEntryModelProducer() }
+    val marker = rememberSimpleMarker()
+    val dayFormatter = remember { DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault()) }
+    LaunchedEffect(entries) {
+        val muscle = entries.mapIndexed { index, item -> entryOf(index.toFloat(), item.skeletalMuscleMass) }
+        val fat = entries.mapIndexed { index, item -> entryOf(index.toFloat(), item.bodyFatRatio) }
+        val water = entries.mapIndexed { index, item -> entryOf(index.toFloat(), item.totalBodyWater) }
+        modelProducer.setEntries(listOf(muscle, fat, water))
+    }
+    val formatter = AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
+        entries.getOrNull(value.toInt())?.timestamp?.let {
+            Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate().format(dayFormatter)
+        } ?: ""
+    }
+    val muscleColor = Color(0xFF81C784)
+    val fatColor = Color(0xFFE57373)
+    val waterColor = Color(0xFF64B5F6)
+    Chart(
+        chart = lineChart(
+            lines = listOf(
+                lineSpec(muscleColor, point = shapeComponent(Shapes.pillShape, muscleColor)),
+                lineSpec(fatColor, point = shapeComponent(Shapes.pillShape, fatColor)),
+                lineSpec(waterColor, point = shapeComponent(Shapes.pillShape, waterColor)),
+            )
+        ),
+        chartModelProducer = modelProducer,
+        startAxis = rememberStartAxis(),
+        bottomAxis = rememberBottomAxis(valueFormatter = formatter),
+        marker = marker,
+    )
+    Spacer(Modifier.height(8.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        LegendItem(muscleColor, stringResource(R.string.skeletal_muscle_mass))
+        LegendItem(fatColor, stringResource(R.string.body_fat_percent))
+        LegendItem(waterColor, stringResource(R.string.total_body_water))
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(modifier = Modifier.size(12.dp).background(color, CircleShape))
+        Spacer(Modifier.width(4.dp))
+        Text(text = label, color = Color.White, fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun rememberSimpleMarker(): Marker {
+    val label = com.patrykandpatrick.vico.compose.component.textComponent(
+        color = Color.White,
+        background = shapeComponent(Shapes.pillShape, Color.DarkGray)
+    )
+    val indicator = shapeComponent(Shapes.pillShape, Color.White)
+    val guideline = lineComponent(Color.White.copy(alpha = 0.2f), 2.dp)
+    return remember { markerComponent(label = label, indicator = indicator, guideline = guideline) }
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/ProgressViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/ProgressViewModel.kt
@@ -1,0 +1,52 @@
+package researchstack.presentation.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import researchstack.data.datasource.local.room.dao.ExerciseDao
+import researchstack.data.local.room.dao.BiaDao
+import researchstack.domain.model.priv.Bia
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import javax.inject.Inject
+
+@HiltViewModel
+class ProgressViewModel @Inject constructor(
+    application: Application,
+    private val exerciseDao: ExerciseDao,
+    private val biaDao: BiaDao,
+) : AndroidViewModel(application) {
+
+    private val dayFormatter = DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault())
+
+    private val _caloriesByDate = MutableStateFlow<List<Pair<String, Float>>>(emptyList())
+    val caloriesByDate: StateFlow<List<Pair<String, Float>>> = _caloriesByDate
+
+    private val _biaEntries = MutableStateFlow<List<Bia>>(emptyList())
+    val biaEntries: StateFlow<List<Bia>> = _biaEntries
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            exerciseDao.getExercisesFrom(0).collect { list ->
+                val grouped = list.groupBy {
+                    Instant.ofEpochMilli(it.startTime).atZone(ZoneId.systemDefault()).toLocalDate()
+                }.toSortedMap()
+                _caloriesByDate.value = grouped.map { (date, exercises) ->
+                    date.format(dayFormatter) to exercises.sumOf { it.calorie }.toFloat()
+                }
+            }
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            biaDao.getBetween(0, Long.MAX_VALUE).collect { list ->
+                _biaEntries.value = list.sortedBy { it.timestamp }
+            }
+        }
+    }
+}

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -225,4 +225,7 @@
     <string name="body_fat_percent">Body Fat %</string>
     <string name="total_body_water">Total Body Water</string>
     <string name="bmr">BMR</string>
+    <string name="insights">Insights</string>
+    <string name="calorie_burn_over_time">Calorie Burn Over Time</string>
+    <string name="bia_progress">BIA Progress</string>
 </resources>


### PR DESCRIPTION
## Summary
- add ProgressScreen for Insights with calorie and BIA line charts
- load data from database in new ProgressViewModel
- route Insights screen and include Vico chart dependencies

## Testing
- `./gradlew :samples:starter-mobile-app:compileDebugKotlin` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_689119482afc832f81eddb411a18f916