### PR TITLE
feat: upgrade Kotlin to 2.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     kotlin("kapt") version Versions.KOTLIN apply false
     id("com.google.protobuf") version Versions.GRPC.PROTOBUF apply false
     id("org.jetbrains.kotlin.android") version Versions.KOTLIN apply false
+    id("org.jetbrains.kotlin.plugin.compose") version Versions.KOTLIN apply false
     id("nl.neotech.plugin.rootcoverage") version Versions.ROOT_COVERAGE
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val APP_VERSION_NAME = "1.0.5"
     const val APP_VERSION_CODE = 4
 
-    const val KOTLIN = "1.9.23"
+    const val KOTLIN = "2.2.0"
 
     object GRPC {
         const val PROTOBUF = "0.9.4"
@@ -78,7 +78,7 @@ object Versions {
 
     // UI
     object Compose {
-        const val COMPILER = "1.5.13"
+        const val COMPILER = KOTLIN
         const val UI = "1.6.8"
         const val ACTIVITY = "1.9.1"
         const val WEARABLE = "1.3.1"

--- a/samples/starter-mobile-app/build.gradle.kts
+++ b/samples/starter-mobile-app/build.gradle.kts
@@ -2,13 +2,13 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
+    id("kotlin-kapt")
     id("dagger.hilt.android.plugin")
     id("com.google.protobuf")
     id("io.gitlab.arturbosch.detekt")
     id("de.mannodermaus.android-junit5")
-    id("org.jetbrains.kotlin.android")
-    id("kotlin-kapt")
 }
 
 fun getProperty(key: String): String {
@@ -93,9 +93,7 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = Versions.Compose.COMPILER
-    }
+
 
     packaging {
         resources.excludes.add("META-INF/*")

--- a/samples/starter-wearable-app/build.gradle.kts
+++ b/samples/starter-wearable-app/build.gradle.kts
@@ -2,7 +2,8 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     id("dagger.hilt.android.plugin")
     id("io.gitlab.arturbosch.detekt")
@@ -77,9 +78,7 @@ android {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = Versions.Compose.COMPILER
-    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/samples/wearable-standalone/build.gradle.kts
+++ b/samples/wearable-standalone/build.gradle.kts
@@ -2,7 +2,8 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     id("dagger.hilt.android.plugin")
     id("io.gitlab.arturbosch.detekt")
@@ -76,9 +77,7 @@ android {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = Versions.Compose.COMPILER
-    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"


### PR DESCRIPTION
## Summary
- upgrade Kotlin to 2.2.0
- apply Kotlin Compose plugin and remove old compiler extension config

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891206c7120832f8ac9b5c6a097e371