### PR TITLE
feat: enhance progress charts and navigation

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
@@ -3,10 +3,11 @@ package researchstack.presentation.screen.main
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -37,10 +38,12 @@ import com.patrykandpatrick.vico.core.entry.ChartEntryModelProducer
 import com.patrykandpatrick.vico.core.entry.entryOf
 import com.patrykandpatrick.vico.core.component.shape.Shapes
 import com.patrykandpatrick.vico.core.marker.Marker
+import com.patrykandpatrick.vico.core.marker.MarkerLabelFormatter
 import researchstack.R
-import researchstack.domain.model.priv.Bia
 import researchstack.presentation.LocalNavController
 import researchstack.presentation.viewmodel.ProgressViewModel
+import researchstack.presentation.util.kgToLbs
+import researchstack.presentation.util.toDecimalFormat
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -51,6 +54,7 @@ fun ProgressScreen(viewModel: ProgressViewModel = hiltViewModel()) {
     val navController = LocalNavController.current
     val calories = viewModel.caloriesByDate.collectAsState().value
     val bia = viewModel.biaEntries.collectAsState().value
+    val isMetric = viewModel.isMetricUnit.collectAsState().value
     val scrollState = rememberScrollState()
 
     Scaffold(
@@ -87,7 +91,40 @@ fun ProgressScreen(viewModel: ProgressViewModel = hiltViewModel()) {
             Spacer(Modifier.height(24.dp))
             Text(text = stringResource(id = R.string.bia_progress), color = Color.White, fontSize = 18.sp)
             Spacer(Modifier.height(8.dp))
-            BiaChart(bia)
+            val dayFormatter = remember { DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault()) }
+            val unit = if (isMetric) stringResource(R.string.kg_unit) else stringResource(R.string.lbs_unit)
+            val muscleData = bia.map {
+                Instant.ofEpochMilli(it.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
+                    .format(dayFormatter) to it.skeletalMuscleMass.kgToLbs(isMetric)
+            }
+            val fatData = bia.map {
+                Instant.ofEpochMilli(it.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
+                    .format(dayFormatter) to it.bodyFatRatio
+            }
+            val waterData = bia.map {
+                Instant.ofEpochMilli(it.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
+                    .format(dayFormatter) to it.totalBodyWater.kgToLbs(isMetric)
+            }
+            BiaMetricChart(
+                title = stringResource(R.string.skeletal_muscle_mass) + " ($unit)",
+                data = muscleData,
+                unit = unit,
+                lineColor = Color(0xFF81C784)
+            )
+            Spacer(Modifier.height(16.dp))
+            BiaMetricChart(
+                title = stringResource(R.string.body_fat_percent),
+                data = fatData,
+                unit = stringResource(R.string.percent_symbol),
+                lineColor = Color(0xFFE57373)
+            )
+            Spacer(Modifier.height(16.dp))
+            BiaMetricChart(
+                title = stringResource(R.string.total_body_water) + " ($unit)",
+                data = waterData,
+                unit = unit,
+                lineColor = Color(0xFF64B5F6)
+            )
         }
     }
 }
@@ -117,55 +154,35 @@ private fun CalorieChart(data: List<Pair<String, Float>>) {
 }
 
 @Composable
-private fun BiaChart(entries: List<Bia>) {
-    if (entries.isEmpty()) {
-        Text(text = stringResource(id = R.string.no_data_available), color = Color.White)
-        return
-    }
-    val modelProducer = remember { ChartEntryModelProducer() }
-    val marker = rememberSimpleMarker()
-    val dayFormatter = remember { DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault()) }
-    LaunchedEffect(entries) {
-        val muscle = entries.mapIndexed { index, item -> entryOf(index.toFloat(), item.skeletalMuscleMass) }
-        val fat = entries.mapIndexed { index, item -> entryOf(index.toFloat(), item.bodyFatRatio) }
-        val water = entries.mapIndexed { index, item -> entryOf(index.toFloat(), item.totalBodyWater) }
-        modelProducer.setEntries(listOf(muscle, fat, water))
-    }
-    val formatter = AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
-        entries.getOrNull(value.toInt())?.timestamp?.let {
-            Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate().format(dayFormatter)
-        } ?: ""
-    }
-    val muscleColor = Color(0xFF81C784)
-    val fatColor = Color(0xFFE57373)
-    val waterColor = Color(0xFF64B5F6)
-    Chart(
-        chart = lineChart(
-            lines = listOf(
-                lineSpec(muscleColor, point = shapeComponent(Shapes.pillShape, muscleColor)),
-                lineSpec(fatColor, point = shapeComponent(Shapes.pillShape, fatColor)),
-                lineSpec(waterColor, point = shapeComponent(Shapes.pillShape, waterColor)),
-            )
-        ),
-        chartModelProducer = modelProducer,
-        startAxis = rememberStartAxis(),
-        bottomAxis = rememberBottomAxis(valueFormatter = formatter),
-        marker = marker,
-    )
-    Spacer(Modifier.height(8.dp))
-    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        LegendItem(muscleColor, stringResource(R.string.skeletal_muscle_mass))
-        LegendItem(fatColor, stringResource(R.string.body_fat_percent))
-        LegendItem(waterColor, stringResource(R.string.total_body_water))
-    }
-}
-
-@Composable
-private fun LegendItem(color: Color, label: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Box(modifier = Modifier.size(12.dp).background(color, CircleShape))
-        Spacer(Modifier.width(4.dp))
-        Text(text = label, color = Color.White, fontSize = 12.sp)
+private fun BiaMetricChart(title: String, data: List<Pair<String, Float>>, unit: String, lineColor: Color) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFF333333)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(title, color = Color.White, fontSize = 16.sp)
+            Spacer(Modifier.height(8.dp))
+            if (data.isEmpty()) {
+                Text(text = stringResource(id = R.string.no_data_available), color = Color.White)
+            } else {
+                val modelProducer = remember { ChartEntryModelProducer() }
+                val marker = rememberBiaMarker(data, unit)
+                LaunchedEffect(data) {
+                    modelProducer.setEntries(data.mapIndexed { index, pair -> entryOf(index.toFloat(), pair.second) })
+                }
+                val formatter = AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
+                    data.getOrNull(value.toInt())?.first ?: ""
+                }
+                Chart(
+                    chart = lineChart(lines = listOf(lineSpec(lineColor, point = shapeComponent(Shapes.pillShape, lineColor)))),
+                    chartModelProducer = modelProducer,
+                    startAxis = rememberStartAxis(title = unit),
+                    bottomAxis = rememberBottomAxis(valueFormatter = formatter),
+                    marker = marker,
+                )
+            }
+        }
     }
 }
 
@@ -177,5 +194,34 @@ private fun rememberSimpleMarker(): Marker {
     )
     val indicator = shapeComponent(Shapes.pillShape, Color.White)
     val guideline = lineComponent(Color.White.copy(alpha = 0.2f), 2.dp)
-    return markerComponent(label = label, indicator = indicator, guideline = guideline)
+    return markerComponent(
+        label = label,
+        indicator = indicator,
+        guideline = guideline
+    )
+}
+
+@Composable
+private fun rememberBiaMarker(data: List<Pair<String, Float>>, unit: String): Marker {
+    val label = textComponent(
+        color = Color.White,
+        background = shapeComponent(Shapes.pillShape, Color.DarkGray)
+    )
+    val indicator = shapeComponent(Shapes.pillShape, Color.White)
+    val guideline = lineComponent(Color.White.copy(alpha = 0.2f), 2.dp)
+    val formatter = remember(data, unit) {
+        MarkerLabelFormatter { marked, _ ->
+            val entry = marked.entries.firstOrNull()?.entry
+            val index = entry?.x?.toInt() ?: 0
+            val date = data.getOrNull(index)?.first ?: ""
+            val value = entry?.y ?: 0f
+            "${date} ${value.toDecimalFormat(2)} $unit"
+        }
+    }
+    return markerComponent(
+        label = label,
+        indicator = indicator,
+        guideline = guideline,
+        labelFormatter = formatter
+    )
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -58,6 +59,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import researchstack.R
 import researchstack.presentation.LocalNavController
 import researchstack.presentation.viewmodel.WeeklyProgressViewModel
+import researchstack.presentation.initiate.route.Route
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -171,6 +173,16 @@ fun WeeklyProgressScreen(
                     fontSize = 20.sp,
                     modifier = Modifier.align(Alignment.Center)
                 )
+                IconButton(
+                    onClick = { navController.navigate(Route.Progress.name) },
+                    modifier = Modifier.align(Alignment.CenterEnd)
+                ) {
+                    Icon(
+                        Icons.Filled.Insights,
+                        contentDescription = stringResource(id = R.string.view_progress),
+                        tint = Color.White
+                    )
+                }
             }
         }
     ) { innerPadding ->

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/ProgressViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/ProgressViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import researchstack.data.datasource.local.room.dao.ExerciseDao
 import researchstack.data.local.room.dao.BiaDao
+import researchstack.data.local.room.dao.UserProfileDao
 import researchstack.domain.model.priv.Bia
 import java.time.Instant
 import java.time.ZoneId
@@ -22,6 +23,7 @@ class ProgressViewModel @Inject constructor(
     application: Application,
     private val exerciseDao: ExerciseDao,
     private val biaDao: BiaDao,
+    private val userProfileDao: UserProfileDao,
 ) : AndroidViewModel(application) {
 
     private val dayFormatter = DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault())
@@ -31,6 +33,9 @@ class ProgressViewModel @Inject constructor(
 
     private val _biaEntries = MutableStateFlow<List<Bia>>(emptyList())
     val biaEntries: StateFlow<List<Bia>> = _biaEntries
+
+    private val _isMetricUnit = MutableStateFlow(true)
+    val isMetricUnit: StateFlow<Boolean> = _isMetricUnit
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -46,6 +51,11 @@ class ProgressViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             biaDao.getBetween(0, Long.MAX_VALUE).collect { list ->
                 _biaEntries.value = list.sortedBy { it.timestamp }
+            }
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            userProfileDao.getLatest().collect { profile ->
+                _isMetricUnit.value = profile?.isMetricUnit != false
             }
         }
     }

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -196,6 +196,9 @@
     <string name="show_details">Show Details</string>
     <string name="kcal_unit">Kcal</string>
     <string name="bpm_unit">BPM</string>
+    <string name="kg_unit">kg</string>
+    <string name="lbs_unit">lbs</string>
+    <string name="percent_symbol">%</string>
     <string name="exercises_on_date">Exercises on %1$s</string>
 
     <string name="weight_details">Weight Details</string>
@@ -207,5 +210,6 @@
     <string name="body_fat_percent">Body Fat %</string>
     <string name="total_body_water">Total Body Water</string>
     <string name="bmr">BMR</string>
+    <string name="view_progress">View Progress</string>
 
 </resources>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -215,6 +215,9 @@
     <string name="show_details">Show Details</string>
     <string name="kcal_unit">Kcal</string>
     <string name="bpm_unit">BPM</string>
+    <string name="kg_unit">kg</string>
+    <string name="lbs_unit">lbs</string>
+    <string name="percent_symbol">%</string>
     <string name="exercises_on_date">Exercises on %1$s</string>
     <string name="weight_details">Weight Details</string>
     <string name="bia_details">BIA Details</string>
@@ -228,4 +231,5 @@
     <string name="insights">Insights</string>
     <string name="calorie_burn_over_time">Calorie Burn Over Time</string>
     <string name="bia_progress">BIA Progress</string>
+    <string name="view_progress">View Progress</string>
 </resources>


### PR DESCRIPTION
## Summary
- split BIA progress into separate muscle, fat and water charts with card styling
- convert muscle and water values based on user weight unit preference
- add analytics icon on Weekly Progress screen to navigate to Progress screen

## Testing
- `./gradlew :samples:starter-mobile-app:lint` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b1f10aa0832f91aeffef8aa80a1d