### PR TITLE
Add minute-level compliance reminders

### DIFF
--- a/samples/starter-mobile-app/src/main/AndroidManifest.xml
+++ b/samples/starter-mobile-app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED"/>
     <uses-permission android:name="android.permission.health.READ_SPEED"/>
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
 
   <uses-permission

--- a/samples/starter-mobile-app/src/main/AndroidManifest.xml
+++ b/samples/starter-mobile-app/src/main/AndroidManifest.xml
@@ -100,6 +100,9 @@
     </receiver>
 
     <receiver android:name="researchstack.util.AlarmReceiver"/>
+    <receiver
+      android:name="researchstack.util.ComplianceCheckReceiver"
+      android:exported="false"/>
 
     <service
       android:foregroundServiceType="health"

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/PrefProvider.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/config/provider/PrefProvider.kt
@@ -1,0 +1,20 @@
+package researchstack.config.provider
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import researchstack.data.datasource.local.pref.ComplianceReminderPref
+import researchstack.data.datasource.local.pref.dataStore
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PrefProvider {
+    @Singleton
+    @Provides
+    fun provideComplianceReminderPref(@ApplicationContext context: Context): ComplianceReminderPref =
+        ComplianceReminderPref(context.dataStore)
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/pref/ComplianceReminderPref.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/pref/ComplianceReminderPref.kt
@@ -1,0 +1,36 @@
+package researchstack.data.datasource.local.pref
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.firstOrNull
+
+class ComplianceReminderPref(private val dataStore: DataStore<Preferences>) {
+    enum class Type { ACTIVITY, RESISTANCE, BIA }
+
+    private val activityKey = stringPreferencesKey("compliance_activity")
+    private val resistanceKey = stringPreferencesKey("compliance_resistance")
+    private val biaKey = stringPreferencesKey("compliance_bia")
+
+    private fun key(type: Type) = when (type) {
+        Type.ACTIVITY -> activityKey
+        Type.RESISTANCE -> resistanceKey
+        Type.BIA -> biaKey
+    }
+
+    suspend fun getLastReminderDate(type: Type): String? =
+        dataStore.data.firstOrNull()?.let { it[key(type)] }
+
+    suspend fun saveReminderDate(type: Type, date: String) {
+        dataStore.edit { prefs ->
+            prefs[key(type)] = date
+        }
+    }
+
+    suspend fun clear(type: Type) {
+        dataStore.edit { prefs ->
+            prefs.remove(key(type))
+        }
+    }
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/MainActivity.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/MainActivity.kt
@@ -2,6 +2,7 @@ package researchstack.presentation.initiate
 
 import android.R
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
@@ -26,6 +27,7 @@ import researchstack.presentation.theme.AppTheme
 import researchstack.presentation.viewmodel.SplashLoadingViewModel
 import researchstack.util.NotificationUtil
 import researchstack.util.setAlarm
+import researchstack.util.scheduleComplianceCheck
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -44,16 +46,18 @@ class MainActivity : ComponentActivity() {
             this.window.statusBarColor = White.toArgb()
             val startDestination: Route? by splashLoadingViewModel.routeDestination.observeAsState()
             val page by splashLoadingViewModel.startMainPage.observeAsState(0)
+            val openWeeklyProgress = intent.getBooleanExtra("openWeeklyProgress", false)
 
             startDestination?.let {
                 AppTheme {
-                    ContentComposable(it, page)
+                    ContentComposable(it, page, openWeeklyProgress)
                 }
             }
         }
 
         setSuspendDrawingTheFirstView()
         setAlarm(this)
+        scheduleComplianceCheck(this)
     }
 
     private fun initSplashLoadingViewModel() {
@@ -67,10 +71,16 @@ class MainActivity : ComponentActivity() {
         splashLoadingViewModel.setStartMainPage()
     }
 
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.let { setIntent(it) }
+    }
+
     @Composable
     private fun ContentComposable(
         startDestination: Route,
         page: Int = 0,
+        openWeeklyProgress: Boolean = false,
     ) {
         Surface {
             val navController = rememberNavController()
@@ -82,6 +92,11 @@ class MainActivity : ComponentActivity() {
                     startRoute = startDestination,
                     askedPage = intent.getIntExtra("page", page),
                 )
+                if (openWeeklyProgress) {
+                    androidx.compose.runtime.LaunchedEffect(Unit) {
+                        navController.navigate(Route.WeeklyProgress.name)
+                    }
+                }
             }
             RegisterSignOutReceiver(navController)
         }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/MainActivity.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/MainActivity.kt
@@ -71,9 +71,9 @@ class MainActivity : ComponentActivity() {
         splashLoadingViewModel.setStartMainPage()
     }
 
-    override fun onNewIntent(intent: Intent?) {
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        intent?.let { setIntent(it) }
+        setIntent(intent)
     }
 
     @Composable

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/MainScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/MainScreen.kt
@@ -36,6 +36,7 @@ import researchstack.presentation.screen.log.LogScreen
 import researchstack.presentation.screen.study.StudyListScreen
 import researchstack.presentation.screen.task.TaskListScreen
 import researchstack.presentation.theme.AppTheme
+import researchstack.presentation.util.checkAlarmPermission
 import researchstack.presentation.util.ignoreBatteryOptimization
 import researchstack.presentation.viewmodel.UISettingViewModel
 
@@ -58,6 +59,7 @@ fun MainScreen(
     PermissionChecker(permissions = permissions) {}
     LaunchedEffect(key1 = "pm") {
         ignoreBatteryOptimization(context)
+        checkAlarmPermission(context)
     }
 
     val coroutineScope = rememberCoroutineScope()

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/service/BootCompletedReceiver.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/service/BootCompletedReceiver.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import researchstack.domain.usecase.sensor.GetPermittedSensorTypesUseCase
 import researchstack.util.setAlarm
+import researchstack.util.scheduleComplianceCheck
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -20,5 +21,6 @@ class BootCompletedReceiver : DaggerBroadcastReceiver() {
                 context.startForegroundService(Intent(context, TrackerDataForegroundService::class.java))
         }
         setAlarm(context)
+        scheduleComplianceCheck(context)
     }
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/util/IgnoreBatteryOptimization.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/util/IgnoreBatteryOptimization.kt
@@ -1,11 +1,15 @@
 package researchstack.presentation.util
 
+import android.app.AlarmManager
 import android.content.Context
 import android.content.Context.POWER_SERVICE
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.PowerManager
 import android.provider.Settings
+import androidx.core.net.toUri
+
 fun ignoreBatteryOptimization(context: Context) {
     val powerManager = context.getSystemService(POWER_SERVICE) as PowerManager
     if (powerManager.isIgnoringBatteryOptimizations(context.packageName)) return
@@ -15,4 +19,15 @@ fun ignoreBatteryOptimization(context: Context) {
             data = Uri.parse("package:" + context.packageName)
         }
     )
+}
+
+fun checkAlarmPermission(context: Context){
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        if (!alarmManager.canScheduleExactAlarms()) {
+            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                .setData(("package:" + context.packageName).toUri())
+            context.startActivity(intent)
+        }
+    }
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceAlarm.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceAlarm.kt
@@ -4,6 +4,7 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 
 private const val COMPLIANCE_REQUEST_CODE = 1000
 private const val INTERVAL_MINUTE = 60_000L
@@ -17,5 +18,11 @@ fun scheduleComplianceCheck(context: Context) {
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
     val triggerAt = System.currentTimeMillis() + INTERVAL_MINUTE
-    manager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !manager.canScheduleExactAlarms()) {
+        // SCHEDULE_EXACT_ALARM is intended for apps like clocks; fall back to an
+        // inexact alarm when the permission isn't granted.
+        manager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+    } else {
+        manager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+    }
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceAlarm.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceAlarm.kt
@@ -1,0 +1,21 @@
+package researchstack.util
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+
+private const val COMPLIANCE_REQUEST_CODE = 1000
+private const val INTERVAL_MINUTE = 60_000L
+
+fun scheduleComplianceCheck(context: Context) {
+    val manager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    val pendingIntent = PendingIntent.getBroadcast(
+        context,
+        COMPLIANCE_REQUEST_CODE,
+        Intent(context, ComplianceCheckReceiver::class.java),
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+    val triggerAt = System.currentTimeMillis() + INTERVAL_MINUTE
+    manager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceCheckReceiver.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceCheckReceiver.kt
@@ -1,0 +1,151 @@
+package researchstack.util
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import researchstack.R
+import researchstack.data.datasource.local.pref.ComplianceReminderPref
+import researchstack.data.datasource.local.pref.EnrollmentDatePref
+import researchstack.data.datasource.local.pref.ComplianceReminderPref.Type
+import researchstack.data.datasource.local.room.dao.ExerciseDao
+import researchstack.data.local.room.dao.BiaDao
+import researchstack.data.local.room.dao.UserProfileDao
+import researchstack.domain.repository.StudyRepository
+import researchstack.presentation.initiate.MainActivity
+import researchstack.presentation.service.DaggerBroadcastReceiver
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+private const val CHANNEL_ID = "weekly_compliance"
+
+@AndroidEntryPoint
+class ComplianceCheckReceiver : DaggerBroadcastReceiver() {
+
+    @Inject
+    lateinit var studyRepository: StudyRepository
+
+    @Inject
+    lateinit var exerciseDao: ExerciseDao
+
+    @Inject
+    lateinit var biaDao: BiaDao
+
+    @Inject
+    lateinit var userProfileDao: UserProfileDao
+
+    @Inject
+    lateinit var enrollmentDatePref: EnrollmentDatePref
+
+    @Inject
+    lateinit var reminderPref: ComplianceReminderPref
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        super.onReceive(context, intent)
+        scheduleComplianceCheck(context)
+        runBlocking {
+            val studyId = studyRepository.getActiveStudies().first().firstOrNull()?.id ?: return@runBlocking
+            val enrollment = enrollmentDatePref.getEnrollmentDate(studyId)?.let { LocalDate.parse(it) } ?: return@runBlocking
+            val today = LocalDate.now()
+            val days = ChronoUnit.DAYS.between(enrollment, today).toInt().coerceAtLeast(0)
+            val weekStart = enrollment.plusDays((days / 7) * 7L)
+            val dayOfWeek = days % 7 + 1
+            val startMillis = weekStart.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            val endMillis = today.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+            val exercises = exerciseDao.getExercisesFrom(startMillis).first().filter { it.startTime < endMillis }
+            val activityRecorded = exercises.any { !isResistance(it.exerciseType.toInt()) }
+            val resistanceRecorded = exercises.any { isResistance(it.exerciseType.toInt()) }
+            val biaCount = biaDao.countBetween(startMillis, endMillis).first()
+            val weightCount = userProfileDao.countBetween(startMillis, endMillis).first()
+            val biaOrWeightRecorded = (biaCount + weightCount) > 0
+
+            if (activityRecorded) reminderPref.clear(Type.ACTIVITY)
+            if (resistanceRecorded) reminderPref.clear(Type.RESISTANCE)
+            if (biaOrWeightRecorded) reminderPref.clear(Type.BIA)
+
+            val todayStr = today.toString()
+            var missingActivity = false
+            var missingResistance = false
+            var missingBia = false
+
+            if (dayOfWeek >= 3 && !activityRecorded && reminderPref.getLastReminderDate(Type.ACTIVITY) != todayStr) {
+                missingActivity = true
+                reminderPref.saveReminderDate(Type.ACTIVITY, todayStr)
+            }
+            if (dayOfWeek >= 4 && !resistanceRecorded && reminderPref.getLastReminderDate(Type.RESISTANCE) != todayStr) {
+                missingResistance = true
+                reminderPref.saveReminderDate(Type.RESISTANCE, todayStr)
+            }
+            if (dayOfWeek == 7 && !biaOrWeightRecorded && reminderPref.getLastReminderDate(Type.BIA) != todayStr) {
+                missingBia = true
+                reminderPref.saveReminderDate(Type.BIA, todayStr)
+            }
+
+            if (missingActivity || missingResistance || missingBia) {
+                val message = buildMessage(missingActivity, missingResistance, missingBia)
+                showNotification(context, message)
+            }
+        }
+    }
+
+    private fun showNotification(context: Context, message: String) {
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            manager.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, CHANNEL_ID, NotificationManager.IMPORTANCE_HIGH)
+            )
+        }
+        val intent = Intent(context, MainActivity::class.java).apply {
+            putExtra("openWeeklyProgress", true)
+        }
+        val pi = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Weekly Progress Reminder")
+            .setContentText(message)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pi)
+            .setAutoCancel(true)
+            .build()
+        manager.notify(2001, notification)
+    }
+
+    private fun buildMessage(activity: Boolean, resistance: Boolean, bia: Boolean): String {
+        return when {
+            activity && resistance && bia -> "You haven’t logged any activity, resistance training, or BIA/weight data this week. Let’s complete your weekly goals!"
+            activity && resistance -> "No physical activity or resistance training logged yet. Let’s get moving!"
+            activity && bia -> "You haven’t logged activity or completed BIA/weight measurements this week. Let’s catch up!"
+            resistance && bia -> "Still missing resistance training and BIA/weight data this week. Time to take action!"
+            activity -> "Don’t forget to get moving! You haven’t logged any physical activity this week."
+            resistance -> "Time to train! You haven’t completed any resistance training this week."
+            bia -> "Please log your BIA or weight. Baseline measurements are due this week."
+            else -> ""
+        }
+    }
+
+    private fun isResistance(exerciseType: Int): Boolean {
+        return when (exerciseType) {
+            androidx.health.connect.client.records.ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING,
+            androidx.health.connect.client.records.ExerciseSessionRecord.EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING,
+            androidx.health.connect.client.records.ExerciseSessionRecord.EXERCISE_TYPE_PILATES,
+            androidx.health.connect.client.records.ExerciseSessionRecord.EXERCISE_TYPE_STRETCHING,
+            androidx.health.connect.client.records.ExerciseSessionRecord.EXERCISE_TYPE_YOGA,
+            androidx.health.connect.client.records.ExerciseSessionRecord.EXERCISE_TYPE_CALISTHENICS -> true
+            else -> false
+        }
+    }
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceCheckReceiver.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceCheckReceiver.kt
@@ -14,6 +14,7 @@ import researchstack.R
 import researchstack.data.datasource.local.pref.ComplianceReminderPref
 import researchstack.data.datasource.local.pref.EnrollmentDatePref
 import researchstack.data.datasource.local.pref.ComplianceReminderPref.Type
+import researchstack.data.datasource.local.pref.dataStore
 import researchstack.data.datasource.local.room.dao.ExerciseDao
 import researchstack.data.local.room.dao.BiaDao
 import researchstack.data.local.room.dao.UserProfileDao
@@ -42,7 +43,6 @@ class ComplianceCheckReceiver : DaggerBroadcastReceiver() {
     @Inject
     lateinit var userProfileDao: UserProfileDao
 
-    @Inject
     lateinit var enrollmentDatePref: EnrollmentDatePref
 
     @Inject
@@ -50,6 +50,7 @@ class ComplianceCheckReceiver : DaggerBroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent?) {
         super.onReceive(context, intent)
+        enrollmentDatePref= EnrollmentDatePref(context.dataStore)
         scheduleComplianceCheck(context)
         runBlocking {
             val studyId = studyRepository.getActiveStudies().first().firstOrNull()?.id ?: return@runBlocking


### PR DESCRIPTION
## Summary
- Schedule compliance checks at boot and from the main activity
- Store reminder timestamps and reschedule alarms every minute
- Evaluate weekly progress and post high-priority notifications that open WeeklyProgress

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891d9d6aee4832f8dbd5bd9f8430efe