### PR TITLE
Show BIA mass metrics in progress and detail views

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/ProgressScreen.kt
@@ -98,13 +98,13 @@ fun ProgressScreen(viewModel: ProgressViewModel = hiltViewModel()) {
                 Instant.ofEpochMilli(it.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
                     .format(dayFormatter) to it.skeletalMuscleMass.kgToLbs(isMetric)
             }
-            val fatData = bia.map {
+            val fatMassData = bia.map {
                 Instant.ofEpochMilli(it.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
-                    .format(dayFormatter) to it.bodyFatRatio
+                    .format(dayFormatter) to it.bodyFatMass.kgToLbs(isMetric)
             }
-            val waterData = bia.map {
+            val fatFreeData = bia.map {
                 Instant.ofEpochMilli(it.timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
-                    .format(dayFormatter) to it.totalBodyWater.kgToLbs(isMetric)
+                    .format(dayFormatter) to it.fatFreeMass.kgToLbs(isMetric)
             }
             BiaMetricChart(
                 title = stringResource(R.string.skeletal_muscle_mass) + " ($unit)",
@@ -114,15 +114,15 @@ fun ProgressScreen(viewModel: ProgressViewModel = hiltViewModel()) {
             )
             Spacer(Modifier.height(16.dp))
             BiaMetricChart(
-                title = stringResource(R.string.body_fat_percent),
-                data = fatData,
-                unit = stringResource(R.string.percent_symbol),
+                title = stringResource(R.string.body_fat_mass) + " ($unit)",
+                data = fatMassData,
+                unit = unit,
                 lineColor = Color(0xFFE57373)
             )
             Spacer(Modifier.height(16.dp))
             BiaMetricChart(
-                title = stringResource(R.string.total_body_water) + " ($unit)",
-                data = waterData,
+                title = stringResource(R.string.fat_free_mass) + " ($unit)",
+                data = fatFreeData,
                 unit = unit,
                 lineColor = Color(0xFF64B5F6)
             )

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeightBiaDetailBottomSheet.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeightBiaDetailBottomSheet.kt
@@ -127,32 +127,24 @@ private fun BiaDetailItem(detail: BiaDetailUi) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                Text(stringResource(id = R.string.body_fat_mass), color = Color.LightGray, fontSize = 16.sp)
+                Text(detail.bodyFatMass, color = Color.White, fontSize = 14.sp)
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(stringResource(id = R.string.fat_free_mass), color = Color.LightGray, fontSize = 16.sp)
+                Text(detail.fatFreeMass, color = Color.White, fontSize = 14.sp)
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Text(stringResource(id = R.string.skeletal_muscle_mass), color = Color.LightGray, fontSize = 16.sp)
                 Text(detail.skeletalMuscleMass, color = Color.White, fontSize = 14.sp)
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(stringResource(id = R.string.body_fat_percent), color = Color.LightGray, fontSize = 16.sp)
-                Text("${detail.bodyFatPercent} %", color = Color.White, fontSize = 14.sp)
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(stringResource(id = R.string.total_body_water), color = Color.LightGray, fontSize = 16.sp)
-                Text(detail.totalBodyWater, color = Color.White, fontSize = 14.sp)
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(stringResource(id = R.string.bmr), color = Color.LightGray, fontSize = 16.sp)
-                Text("${detail.basalMetabolicRate} ${stringResource(id = R.string.kcal_unit)}", color = Color.White, fontSize = 14.sp)
             }
         }
     }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/WeeklyProgressViewModel.kt
@@ -246,14 +246,14 @@ class WeeklyProgressViewModel @Inject constructor(
         val date = instant.toLocalDate().format(dateFormatter)
         val time = instant.toLocalTime().format(timeFormatter)
         val unit = if (!isMetric) "lbs" else "kg"
+        val fatMass = bodyFatMass.kgToLbs(isMetric).toDecimalFormat(2)
+        val fatFree = fatFreeMass.kgToLbs(isMetric).toDecimalFormat(2)
         val muscle = skeletalMuscleMass.kgToLbs(isMetric).toDecimalFormat(2)
-        val water = totalBodyWater.kgToLbs(isMetric).toDecimalFormat(2)
         return BiaDetailUi(
             timestamp = "$date $time",
+            bodyFatMass = "$fatMass $unit",
+            fatFreeMass = "$fatFree $unit",
             skeletalMuscleMass = "$muscle $unit",
-            bodyFatPercent = bodyFatRatio.toDecimalFormat(2),
-            totalBodyWater = "$water $unit",
-            basalMetabolicRate = basalMetabolicRate.toDecimalFormat(2)
         )
     }
 }
@@ -276,9 +276,8 @@ data class WeightDetailUi(
 
 data class BiaDetailUi(
     val timestamp: String,
+    val bodyFatMass: String,
+    val fatFreeMass: String,
     val skeletalMuscleMass: String,
-    val bodyFatPercent: Float,
-    val totalBodyWater: String,
-    val basalMetabolicRate: Float,
 )
 

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -207,9 +207,8 @@
     <string name="no_bia_data_week">No BIA data for this week.</string>
     <string name="timestamp_label">Timestamp</string>
     <string name="skeletal_muscle_mass">Skeletal Muscle Mass</string>
-    <string name="body_fat_percent">Body Fat %</string>
-    <string name="total_body_water">Total Body Water</string>
-    <string name="bmr">BMR</string>
+    <string name="body_fat_mass">Body Fat Mass</string>
+    <string name="fat_free_mass">Fat Free Mass</string>
     <string name="view_progress">View Progress</string>
     <string name="weight_progress">Weight Progress</string>
 

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -225,9 +225,8 @@
     <string name="no_bia_data_week">No BIA data for this week.</string>
     <string name="timestamp_label">Timestamp</string>
     <string name="skeletal_muscle_mass">Skeletal Muscle Mass</string>
-    <string name="body_fat_percent">Body Fat %</string>
-    <string name="total_body_water">Total Body Water</string>
-    <string name="bmr">BMR</string>
+    <string name="body_fat_mass">Body Fat Mass</string>
+    <string name="fat_free_mass">Fat Free Mass</string>
     <string name="insights">Insights</string>
     <string name="calorie_burn_over_time">Calorie Burn Over Time</string>
     <string name="bia_progress">BIA Progress</string>


### PR DESCRIPTION
## Summary
- replace BIA detail list values with body fat mass, fat free mass, and skeletal muscle mass
- chart body fat mass and fat free mass instead of body fat % and total body water on progress screen
- map BIA entries to new mass fields and add supporting string resources

## Testing
- `./gradlew :samples:starter-mobile-app:build` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68933c102748832fa00cfb3886101022