### PR TITLE
Add adherence tab with compliance reminders

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/AdherenceTabScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/AdherenceTabScreen.kt
@@ -1,0 +1,66 @@
+package researchstack.presentation.screen.main
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import researchstack.presentation.viewmodel.DashboardViewModel
+
+@Composable
+fun AdherenceTabScreen(
+    dashboardViewModel: DashboardViewModel = hiltViewModel()
+) {
+    val activityMinutes by dashboardViewModel.totalDurationMinutes.collectAsState()
+    val resistanceSessions by dashboardViewModel.resistanceExercises.collectAsState()
+    val biaCount by dashboardViewModel.biaCount.collectAsState()
+    val weightCount by dashboardViewModel.weightCount.collectAsState()
+    val currentWeek by dashboardViewModel.currentWeek.collectAsState()
+    val currentDay by dashboardViewModel.currentDay.collectAsState()
+    val messages = remember(activityMinutes, resistanceSessions, biaCount, weightCount, currentWeek, currentDay) {
+        val list = mutableListOf<String>()
+        if (activityMinutes < DashboardViewModel.ACTIVITY_GOAL_MINUTES) {
+            list.add("You’ve logged ${activityMinutes} minutes of activity. Target: 150 minutes per week.")
+        }
+        if (resistanceSessions.size < DashboardViewModel.RESISTANCE_SESSION_GOAL) {
+            list.add("You’ve completed ${resistanceSessions.size} resistance session(s). Goal: 2 sessions per week.")
+        }
+        val showBaseline = currentWeek == 1 && currentDay <= 7 && biaCount == 0 && weightCount == 0
+        if (showBaseline) {
+            list.add("Reminder: Complete BIA or weight reading by Day 7 as part of your clinic baseline requirement.")
+        }
+        if (list.isEmpty()) {
+            list.add("You're all set for this week. Keep up the great work!")
+        }
+        list
+    }
+
+    LazyColumn(
+        modifier = Modifier.padding(bottom = 80.dp)
+    ) {
+        items(messages) { message ->
+            Card(
+                modifier = Modifier
+                    .padding(horizontal = 24.dp, vertical = 8.dp),
+                colors = CardDefaults.cardColors(Color(0xFF333333)),
+                elevation = CardDefaults.cardElevation(4.dp)
+            ) {
+                Text(
+                    text = message,
+                    color = Color.White,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+    }
+}
+

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -81,6 +81,7 @@ fun DashboardScreen(
 ) {
     val context = LocalContext.current
     val weeklyTab = stringResource(id = R.string.weekly)
+    val adherenceTab = stringResource(id = R.string.adherence)
     var activeTab by remember { mutableStateOf(weeklyTab) }
     var showSyncDialog by remember { mutableStateOf(false) }
     val scrollState = rememberScrollState()
@@ -311,19 +312,21 @@ fun DashboardScreen(
                             horizontalArrangement = Arrangement.spacedBy(32.dp)
                         ) {
                             TabButton(
-                                stringResource(id = R.string.weekly),
-                                activeTab == stringResource(id = R.string.weekly)
+                                weeklyTab,
+                                activeTab == weeklyTab
                             ) {
+                                activeTab = weeklyTab
                             }
                             TabButton(
-                                stringResource(id = R.string.adherence),
-                                activeTab == stringResource(id = R.string.adherence)
+                                adherenceTab,
+                                activeTab == adherenceTab
                             ) {
+                                activeTab = adherenceTab
                             }
                         }
                         Spacer(Modifier.height(16.dp))
 
-                        if (activeTab == stringResource(id = R.string.weekly)) {
+                        if (activeTab == weeklyTab) {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
                                 modifier = Modifier.clickable { navController.navigate(Route.WeeklyProgress.name) }
@@ -362,6 +365,8 @@ fun DashboardScreen(
                                     Color(0xFFFFA500)
                                 )
                             }
+                        } else {
+                            AdherenceTabScreen(dashboardViewModel)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- track current week/day and weight entries in `DashboardViewModel`
- show weekly compliance reminders in new `AdherenceTabScreen`
- wire Dashboard screen to switch between Weekly and Adherence tabs

## Testing
- `./gradlew :samples:starter-mobile-app:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947766906c832f8f5d463c082d69d4