### PR TITLE
Add average weight tracking to compliance sync

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/ResearchAppDatabase.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/ResearchAppDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import researchstack.data.datasource.local.room.converter.EligibilityConverter
 import researchstack.data.datasource.local.room.converter.LocalDateTimeConverter
 import researchstack.data.datasource.local.room.converter.MapConverter
@@ -32,11 +34,12 @@ import researchstack.data.datasource.local.room.entity.StudyEntity
 import researchstack.data.datasource.local.room.entity.TaskEntity
 import researchstack.domain.model.healthConnect.Exercise
 import researchstack.domain.model.ComplianceEntry
+import researchstack.domain.model.COMPLIANCE_ENTRY_TABLE_NAME
 import researchstack.domain.model.sensor.Accelerometer
 import researchstack.domain.model.sensor.Light
 
 @Database(
-    version = 8,
+    version = 9,
     exportSchema = false,
     entities = [
         StudyEntity::class,
@@ -80,6 +83,12 @@ abstract class ResearchAppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: ResearchAppDatabase? = null
 
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE $COMPLIANCE_ENTRY_TABLE_NAME ADD COLUMN avgWeight REAL NOT NULL DEFAULT 0")
+            }
+        }
+
         fun getDatabase(
             context: Context,
         ): ResearchAppDatabase =
@@ -89,6 +98,7 @@ abstract class ResearchAppDatabase : RoomDatabase() {
                     ResearchAppDatabase::class.java,
                     "research_app_db"
                 )
+                    .addMigrations(MIGRATION_8_9)
                     .fallbackToDestructiveMigration()
                     .addTypeConverter(EligibilityConverter())
                     .addTypeConverter(LocalDateTimeConverter())

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
@@ -231,7 +231,9 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
             ).toInt()
             val resistanceCount = exercises.count { it.isResistance }
             val biaCount = biaDao.countBetween(startMillis, endMillis).first()
-            val weightCount = userProfileDao.countBetween(startMillis, endMillis).first()
+            val weightEntries = userProfileDao.getBetween(startMillis, endMillis).first()
+            val weightCount = weightEntries.size
+            val avgWeight = if (weightEntries.isEmpty()) 0f else weightEntries.map { it.weight }.average().toFloat()
             entries.add(
                 ComplianceEntry(
                     weekNumber = weekNumber,
@@ -242,6 +244,7 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
                     resistanceSessionCount = resistanceCount,
                     biaRecordCount = biaCount,
                     weightRecordCount = weightCount,
+                    avgWeight = avgWeight,
                 )
             )
             weekStart = weekStart.plusWeeks(1)

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/model/ComplianceEntry.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/model/ComplianceEntry.kt
@@ -1,5 +1,6 @@
 package researchstack.domain.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import researchstack.domain.model.TimestampMapData
@@ -17,6 +18,8 @@ data class ComplianceEntry(
     val resistanceSessionCount: Int,
     val biaRecordCount: Int,
     val weightRecordCount: Int,
+    @ColumnInfo(defaultValue = "0")
+    val avgWeight: Float = 0F,
     override val timeOffset: Int = getCurrentTimeOffset(),
 ) : TimestampMapData {
     override fun toDataMap(): Map<String, Any> = mapOf(
@@ -28,6 +31,7 @@ data class ComplianceEntry(
         ::resistanceSessionCount.name to resistanceSessionCount,
         ::biaRecordCount.name to biaRecordCount,
         ::weightRecordCount.name to weightRecordCount,
+        ::avgWeight.name to avgWeight,
         ::timeOffset.name to timeOffset,
     )
 }


### PR DESCRIPTION
## Summary
- track average weekly weight in `ComplianceEntry`
- compute and sync average weight from user profile data
- migrate local DB to add `avgWeight` column

## Testing
- `./gradlew test --stacktrace` *(fails: Gradle daemon did not finish; Android SDK missing?)*

------
https://chatgpt.com/codex/tasks/task_e_6894a2ee9874832f8310e289ad394fe1