### PR TITLE
Add rewards screen for weekly compliance

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
@@ -16,6 +16,7 @@ enum class Route {
     Intro,
     Progress,
     WeeklyProgress,
+    Rewards,
 }
 
 enum class MainPage {

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -11,6 +11,7 @@ import researchstack.presentation.screen.insight.StudyPermissionSettingScreen
 import researchstack.presentation.screen.insight.StudyStatusScreen
 import researchstack.presentation.screen.main.MainScreen
 import researchstack.presentation.screen.main.ProgressScreen
+import researchstack.presentation.screen.main.RewardsScreen
 import researchstack.presentation.screen.main.WeeklyProgressScreen
 import researchstack.presentation.screen.study.EligibilityFailScreen
 import researchstack.presentation.screen.study.StudyCodeInputScreen
@@ -40,6 +41,9 @@ fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) 
         }
         composable(Route.WeeklyProgress.name) {
             WeeklyProgressScreen()
+        }
+        composable(Route.Rewards.name) {
+            RewardsScreen()
         }
         composable(Route.Welcome.name) {
             WelcomeScreen()

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/RewardsScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/RewardsScreen.kt
@@ -1,0 +1,167 @@
+package researchstack.presentation.screen.main
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import researchstack.R
+import researchstack.presentation.LocalNavController
+import researchstack.presentation.viewmodel.RewardsViewModel
+
+@Composable
+fun RewardsScreen(
+    viewModel: RewardsViewModel = hiltViewModel(),
+) {
+    val navController = LocalNavController.current
+    val activityWeeks by viewModel.activityRewardWeeks.collectAsState()
+    val resistanceWeeks by viewModel.resistanceRewardWeeks.collectAsState()
+    val biaWeeks by viewModel.biaRewardWeeks.collectAsState()
+    val weightWeeks by viewModel.weightRewardWeeks.collectAsState()
+    val championWeeks by viewModel.championRewardWeeks.collectAsState()
+
+    Scaffold(
+        containerColor = Color(0xFF222222),
+        topBar = {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black)
+                    .padding(8.dp)
+            ) {
+                IconButton(
+                    onClick = { navController.popBackStack() },
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(id = R.string.close),
+                        tint = Color.White
+                    )
+                }
+                Text(
+                    text = stringResource(id = R.string.rewards),
+                    color = Color.White,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 20.sp,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            RewardSection(
+                title = stringResource(id = R.string.activity_rewards),
+                weeks = activityWeeks,
+                badgeRes = R.drawable.activity
+            )
+            RewardSection(
+                title = stringResource(id = R.string.resistance_rewards),
+                weeks = resistanceWeeks,
+                badgeRes = R.drawable.resistance
+            )
+            RewardSection(
+                title = stringResource(id = R.string.bia_rewards),
+                weeks = biaWeeks,
+                badgeRes = R.drawable.bia
+            )
+            RewardSection(
+                title = stringResource(id = R.string.weight_rewards),
+                weeks = weightWeeks,
+                badgeRes = R.drawable.weight
+            )
+            RewardSection(
+                title = stringResource(id = R.string.champion_rewards),
+                weeks = championWeeks,
+                badgeRes = R.drawable.champion
+            )
+        }
+    }
+}
+
+@Composable
+private fun RewardSection(
+    title: String,
+    weeks: List<Int>,
+    @DrawableRes badgeRes: Int,
+) {
+    if (weeks.isEmpty()) return
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            color = Color.White,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(Modifier.height(8.dp))
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            items(weeks) { week ->
+                Card(
+                    shape = RoundedCornerShape(8.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color(0xFF2A2A2A)),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .size(width = 80.dp, height = 100.dp)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.week_label, week),
+                            color = Color.White,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Image(
+                            painter = painterResource(id = badgeRes),
+                            contentDescription = null,
+                            modifier = Modifier.size(64.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/WeeklyProgressScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material.icons.filled.EventBusy
 import androidx.compose.material.icons.filled.Insights
+import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -175,15 +176,21 @@ fun WeeklyProgressScreen(
                     fontSize = 20.sp,
                     modifier = Modifier.align(Alignment.Center)
                 )
-                IconButton(
-                    onClick = { navController.navigate(Route.Progress.name) },
-                    modifier = Modifier.align(Alignment.CenterEnd)
-                ) {
-                    Icon(
-                        Icons.Filled.Insights,
-                        contentDescription = stringResource(id = R.string.view_progress),
-                        tint = Color.White
-                    )
+                Row(modifier = Modifier.align(Alignment.CenterEnd)) {
+                    IconButton(onClick = { navController.navigate(Route.Rewards.name) }) {
+                        Icon(
+                            Icons.Filled.EmojiEvents,
+                            contentDescription = stringResource(id = R.string.view_rewards),
+                            tint = Color.White
+                        )
+                    }
+                    IconButton(onClick = { navController.navigate(Route.Progress.name) }) {
+                        Icon(
+                            Icons.Filled.Insights,
+                            contentDescription = stringResource(id = R.string.view_progress),
+                            tint = Color.White
+                        )
+                    }
                 }
             }
         }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/RewardsViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/RewardsViewModel.kt
@@ -1,0 +1,105 @@
+package researchstack.presentation.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import researchstack.data.datasource.local.pref.EnrollmentDatePref
+import researchstack.data.datasource.local.pref.dataStore
+import researchstack.data.datasource.local.room.dao.ExerciseDao
+import researchstack.data.local.room.dao.BiaDao
+import researchstack.data.local.room.dao.UserProfileDao
+import researchstack.domain.repository.StudyRepository
+import researchstack.util.WEEKLY_ACTIVITY_GOAL_MINUTES
+import researchstack.util.WEEKLY_RESISTANCE_SESSION_COUNT
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@HiltViewModel
+class RewardsViewModel @Inject constructor(
+    application: Application,
+    private val studyRepository: StudyRepository,
+    private val exerciseDao: ExerciseDao,
+    private val biaDao: BiaDao,
+    private val userProfileDao: UserProfileDao,
+) : AndroidViewModel(application) {
+
+    private val enrollmentDatePref = EnrollmentDatePref(application.dataStore)
+
+    private val _activityRewardWeeks = MutableStateFlow<List<Int>>(emptyList())
+    val activityRewardWeeks: StateFlow<List<Int>> = _activityRewardWeeks
+
+    private val _resistanceRewardWeeks = MutableStateFlow<List<Int>>(emptyList())
+    val resistanceRewardWeeks: StateFlow<List<Int>> = _resistanceRewardWeeks
+
+    private val _biaRewardWeeks = MutableStateFlow<List<Int>>(emptyList())
+    val biaRewardWeeks: StateFlow<List<Int>> = _biaRewardWeeks
+
+    private val _weightRewardWeeks = MutableStateFlow<List<Int>>(emptyList())
+    val weightRewardWeeks: StateFlow<List<Int>> = _weightRewardWeeks
+
+    private val _championRewardWeeks = MutableStateFlow<List<Int>>(emptyList())
+    val championRewardWeeks: StateFlow<List<Int>> = _championRewardWeeks
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            val studyId = studyRepository.getActiveStudies().firstOrNull()?.firstOrNull()?.id
+            if (studyId != null) {
+                enrollmentDatePref.getEnrollmentDate(studyId)?.let { startStr ->
+                    val startDate = LocalDate.parse(startStr)
+                    loadRewards(startDate)
+                }
+            }
+        }
+    }
+
+    private suspend fun loadRewards(start: LocalDate) {
+        val today = LocalDate.now()
+        val weeks = ChronoUnit.WEEKS.between(start, today).toInt().coerceAtLeast(0)
+        val activity = mutableListOf<Int>()
+        val resistance = mutableListOf<Int>()
+        val bia = mutableListOf<Int>()
+        val weight = mutableListOf<Int>()
+
+        for (i in 0..weeks) {
+            val weekStart = start.plusWeeks(i.toLong())
+            val weekEnd = weekStart.plusDays(7)
+            val startMillis = weekStart.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            val endMillis = weekEnd.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+            val exercises = exerciseDao.getExercisesBetween(startMillis, endMillis).first()
+            val activityMinutes = exercises.filterNot { it.isResistance }
+                .sumOf { TimeUnit.MILLISECONDS.toMinutes(it.endTime - it.startTime).toInt() }
+            val resistanceCount = exercises.count { it.isResistance }
+            if (activityMinutes >= WEEKLY_ACTIVITY_GOAL_MINUTES) activity.add(i + 1)
+            if (resistanceCount >= WEEKLY_RESISTANCE_SESSION_COUNT) resistance.add(i + 1)
+
+            val biaCount = biaDao.countBetween(startMillis, endMillis).first()
+            if (biaCount > 0) bia.add(i + 1)
+            val weightCount = userProfileDao.countBetween(startMillis, endMillis).first()
+            if (weightCount > 0) weight.add(i + 1)
+        }
+
+        _activityRewardWeeks.value = activity
+        _resistanceRewardWeeks.value = resistance
+        _biaRewardWeeks.value = bia
+        _weightRewardWeeks.value = weight
+
+        val champion = activity.toSet()
+            .intersect(resistance.toSet())
+            .intersect(bia.toSet())
+            .intersect(weight.toSet())
+            .toList()
+            .sorted()
+        _championRewardWeeks.value = champion
+    }
+}
+

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -237,4 +237,12 @@
     <string name="weekly_message_resistance_one">You’ve completed 1 resistance training session. Aim for 2 sessions each week.</string>
     <string name="weekly_message_bia_none">Don’t forget to record your body composition this week.</string>
     <string name="weekly_message_weight_none">Update your weight once this week to track your progress.</string>
+    <string name="rewards">Rewards</string>
+    <string name="activity_rewards">Activity Rewards</string>
+    <string name="resistance_rewards">Resistance Rewards</string>
+    <string name="bia_rewards">BIA Rewards</string>
+    <string name="weight_rewards">Weight Rewards</string>
+    <string name="champion_rewards">Champion Rewards</string>
+    <string name="view_rewards">View Rewards</string>
+    <string name="week_label">Week - %1$d</string>
 </resources>


### PR DESCRIPTION
## Summary
- add RewardsScreen that showcases earned badges by week for activity, resistance, BIA, weight, and champion compliance
- wire Rewards route into navigation and WeeklyProgress top bar
- implement RewardsViewModel to compute compliant weeks and champion weeks

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c503e094832f8a9c05c85ca83c89