### PR TITLE
Schedule compliance check at 6 PM daily

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceAlarm.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/util/ComplianceAlarm.kt
@@ -5,9 +5,11 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 private const val COMPLIANCE_REQUEST_CODE = 1000
-private const val INTERVAL_MINUTE = 60_000L
+private const val CHECK_HOUR = 18
 
 fun scheduleComplianceCheck(context: Context) {
     val manager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
@@ -17,7 +19,12 @@ fun scheduleComplianceCheck(context: Context) {
         Intent(context, ComplianceCheckReceiver::class.java),
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
-    val triggerAt = System.currentTimeMillis() + INTERVAL_MINUTE
+    val now = LocalDateTime.now()
+    var nextTrigger = now.withHour(CHECK_HOUR).withMinute(0).withSecond(0).withNano(0)
+    if (!nextTrigger.isAfter(now)) {
+        nextTrigger = nextTrigger.plusDays(1)
+    }
+    val triggerAt = nextTrigger.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !manager.canScheduleExactAlarms()) {
         // SCHEDULE_EXACT_ALARM is intended for apps like clocks; fall back to an
         // inexact alarm when the permission isn't granted.


### PR DESCRIPTION
## Summary
- trigger compliance alarm at 6 PM each day instead of every minute

## Testing
- `./gradlew test` *(fails: SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/workspace/app-sdk/local.properties'.)*

------
https://chatgpt.com/codex/tasks/task_e_6895dee2c258832f940dc413fbf563d9