### PR TITLE
Add week number to BIA sync

### DIFF
--- a/common/src/main/kotlin/researchstack/domain/model/priv/Bia.kt
+++ b/common/src/main/kotlin/researchstack/domain/model/priv/Bia.kt
@@ -23,6 +23,7 @@ data class Bia(
     val totalBodyWater: Float = 0f,
     val measurementProgress: Float = 0f,
     val status: Int = 0,
+    val weekNumber: Int = 0,
     override val timeOffset: Int = getCurrentTimeOffset(),
 ) : TimestampMapData {
     override fun toDataMap(): Map<String, Any> =
@@ -38,6 +39,7 @@ data class Bia(
             ::totalBodyWater.name to totalBodyWater,
             ::measurementProgress.name to measurementProgress,
             ::status.name to status,
+            ::weekNumber.name to weekNumber,
             ::timeOffset.name to timeOffset,
         )
 }

--- a/common/src/test/kotlin/researchstack/model/BiaTest.kt
+++ b/common/src/test/kotlin/researchstack/model/BiaTest.kt
@@ -25,6 +25,7 @@ class BiaTest {
         val measurementProgress = 80f
         val status = 0
         val timeOffset = getCurrentTimeOffset()
+        val weekNumber = 1
         val expectedMap = mapOf(
             "timestamp" to timestamp,
             "basalMetabolicRate" to basalMetabolicRate,
@@ -37,6 +38,7 @@ class BiaTest {
             "totalBodyWater" to totalBodyWater,
             "measurementProgress" to measurementProgress,
             "status" to status,
+            "weekNumber" to weekNumber,
             "timeOffset" to timeOffset,
         )
 
@@ -52,6 +54,7 @@ class BiaTest {
             totalBodyWater,
             measurementProgress,
             status,
+            weekNumber,
             timeOffset
         )
         val dataMap = bia.toDataMap()


### PR DESCRIPTION
## Summary
- store week number for BIA samples
- derive week numbers from enrollment date when syncing wearable BIA files

## Testing
- `./gradlew :common:test` *(fails: SDK location not found)*
- `./gradlew :samples:starter-mobile-app:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896539ef3d0832faef20e51034fbc1c