### PR TITLE
feat: add app settings screen

### DIFF
--- a/samples/starter-mobile-app/build.gradle.kts
+++ b/samples/starter-mobile-app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import org.gradle.kotlin.dsl.wearApp
 
 plugins {
     id("com.android.application")
@@ -74,7 +75,7 @@ android {
             dimension = "env"
             applicationId = "com.mgb.beaumont.glp1activitytracking.dev"
             buildConfigField("String", "SERVER_ADDRESS", "\"192.168.1.20\"")
-            resValue("string","app_name","MGH BICEP (Dev)")
+            resValue("string","app_name","MGH BICEP")
         }
         create("prod") {
             dimension = "env"
@@ -152,6 +153,7 @@ dependencies {
     implementation(AppDependencies.JACKSON_MODULE_KOTLIN)
     implementation(AppDependencies.COMMONS_MATH)
     implementation(AppDependencies.GOOGLE_HEALTH_CONNECT)
+    implementation("androidx.browser:browser:1.9.0")
     kapt(AppDependencies.hiltKaptLibs)
     implementation(AppDependencies.ACCOMPANIST_PAGER)
     implementation(AppDependencies.COIL_COMPOSE)

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -103,9 +103,7 @@ fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) 
         composable(Route.Settings.name) {
             val context = LocalContext.current
             AppSettingsScreen(
-                onBack = { navController.popBackStack() },
                 onOpenUrl = { openUrl(context, it) },
-                showBackButton = true
             )
         }
     }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -6,7 +6,8 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import researchstack.presentation.screen.insight.SettingScreen
+import androidx.compose.ui.platform.LocalContext
+import researchstack.presentation.screen.settings.AppSettingsScreen
 import researchstack.presentation.screen.insight.StudyPermissionSettingScreen
 import researchstack.presentation.screen.insight.StudyStatusScreen
 import researchstack.presentation.screen.main.MainScreen
@@ -22,6 +23,7 @@ import researchstack.presentation.screen.task.TaskScreen
 import researchstack.presentation.screen.welcome.AppIntroScreen
 import researchstack.presentation.screen.welcome.LoginScreen
 import researchstack.presentation.screen.welcome.WelcomeScreen
+import researchstack.presentation.util.openUrl
 
 private val mainRouteName = "${Route.Main.name}/{page}"
 
@@ -99,7 +101,12 @@ fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) 
             }
         }
         composable(Route.Settings.name) {
-            SettingScreen()
+            val context = LocalContext.current
+            AppSettingsScreen(
+                onBack = { navController.popBackStack() },
+                onOpenUrl = { openUrl(context, it) },
+                showBackButton = true
+            )
         }
     }
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/MainScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/MainScreen.kt
@@ -106,7 +106,6 @@ fun MainScreen(
                 BottomPager.StudyList.ordinal -> StudyListScreen()
                 BottomPager.Data.ordinal -> DashboardScreen()
                 BottomPager.Settings.ordinal -> AppSettingsScreen(
-                    onBack = {},
                     onOpenUrl = { openUrl(context, it) }
                 )
                 BottomPager.Log.ordinal -> LogScreen()

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/MainScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/MainScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -36,7 +38,9 @@ import researchstack.presentation.PermissionChecker
 import researchstack.presentation.screen.log.LogScreen
 import researchstack.presentation.screen.study.StudyListScreen
 import researchstack.presentation.screen.task.TaskListScreen
+import researchstack.presentation.screen.settings.AppSettingsScreen
 import researchstack.presentation.theme.AppTheme
+import researchstack.presentation.util.openUrl
 import researchstack.presentation.util.checkAlarmPermission
 import researchstack.presentation.util.ignoreBatteryOptimization
 import researchstack.presentation.viewmodel.UISettingViewModel
@@ -45,6 +49,7 @@ enum class BottomPager(@StringRes val titleId: Int, val imageVectorId: Int) {
     Data(R.string.home_data, R.drawable.home_data),
     StudyList(R.string.home_study_list, R.drawable.home_study_list),
     TaskList(R.string.home_task_list, R.drawable.home_task_list),
+    Settings(R.string.settings, 0),
     Log(R.string.log_page, R.drawable.ic_walk)
 }
 
@@ -98,11 +103,12 @@ fun MainScreen(
         ) { page ->
             when (page) {
                 BottomPager.TaskList.ordinal -> TaskListScreen()
-
                 BottomPager.StudyList.ordinal -> StudyListScreen()
-
                 BottomPager.Data.ordinal -> DashboardScreen()
-
+                BottomPager.Settings.ordinal -> AppSettingsScreen(
+                    onBack = {},
+                    onOpenUrl = { openUrl(context, it) }
+                )
                 BottomPager.Log.ordinal -> LogScreen()
             }
         }
@@ -117,8 +123,13 @@ private fun RowScope.BottomPageItem(
 ) {
     BottomNavigationItem(
         icon = {
+            val image = if (page == BottomPager.Settings) {
+                Icons.Default.Settings
+            } else {
+                ImageVector.vectorResource(page.imageVectorId)
+            }
             Icon(
-                imageVector = ImageVector.vectorResource(page.imageVectorId),
+                imageVector = image,
                 contentDescription = "",
                 modifier = Modifier.size(24.dp)
             )

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/settings/AppSettingsScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/settings/AppSettingsScreen.kt
@@ -1,7 +1,9 @@
 package researchstack.presentation.screen.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -9,16 +11,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,7 +28,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -36,21 +36,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.sp
 import researchstack.BuildConfig
+import researchstack.R
+import researchstack.presentation.LocalNavController
 import researchstack.presentation.util.ABOUT_URL
 import researchstack.presentation.util.PRIVACY_URL
 import researchstack.presentation.util.contactSupport
 
 @Composable
 fun AppSettingsScreen(
-    onBack: () -> Unit,
     onOpenUrl: (String) -> Unit,
-    showBackButton: Boolean = false
 ) {
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -64,20 +68,22 @@ fun AppSettingsScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text(text = "Settings") },
-                navigationIcon = {
-                    if (showBackButton) {
-                        IconButton(onClick = onBack) {
-                            Icon(
-                                imageVector = Icons.Default.ArrowBack,
-                                contentDescription = "Back"
-                            )
-                        }
-                    }
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors()
-            )
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black)
+                    .padding(16.dp)
+            ) {
+                IconButton(onClick = { navController.popBackStack() }, modifier = Modifier.align(Alignment.CenterStart)) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = Color.White)
+                }
+                Text(
+                    text = stringResource(id = R.string.insights),
+                    color = Color.White,
+                    fontSize = 20.sp,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { inner ->
@@ -192,17 +198,5 @@ private fun KeyValueRow(key: String, value: String) {
             )
         )
     }
-}
-
-@Preview
-@Composable
-private fun AppSettingsScreenPreview() {
-    AppSettingsScreen(onBack = {}, onOpenUrl = {})
-}
-
-@Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
-@Composable
-private fun AppSettingsScreenDarkPreview() {
-    AppSettingsScreen(onBack = {}, onOpenUrl = {})
 }
 

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/settings/AppSettingsScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/settings/AppSettingsScreen.kt
@@ -1,0 +1,208 @@
+package researchstack.presentation.screen.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.content.pm.PackageInfoCompat
+import androidx.compose.foundation.shape.RoundedCornerShape
+import researchstack.BuildConfig
+import researchstack.presentation.util.ABOUT_URL
+import researchstack.presentation.util.PRIVACY_URL
+import researchstack.presentation.util.contactSupport
+
+@Composable
+fun AppSettingsScreen(
+    onBack: () -> Unit,
+    onOpenUrl: (String) -> Unit,
+    showBackButton: Boolean = false
+) {
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    val versionName = BuildConfig.VERSION_NAME
+    val versionCode = remember {
+        PackageInfoCompat.getLongVersionCode(
+            context.packageManager.getPackageInfo(context.packageName, 0)
+        ).toString()
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(text = "Settings") },
+                navigationIcon = {
+                    if (showBackButton) {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.Default.ArrowBack,
+                                contentDescription = "Back"
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors()
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { inner ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item {
+                Card(
+                    shape = RoundedCornerShape(24.dp),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 3.dp)
+                ) {
+                    Column {
+                        SettingsItem(
+                            title = "About Us",
+                            icon = Icons.Default.Info,
+                            contentDescription = "About Us",
+                            onClick = { onOpenUrl(ABOUT_URL) }
+                        )
+                        Divider()
+                        SettingsItem(
+                            title = "Privacy Policy",
+                            icon = Icons.Default.Lock,
+                            contentDescription = "Privacy Policy",
+                            onClick = { onOpenUrl(PRIVACY_URL) }
+                        )
+                        Divider()
+                        SettingsItem(
+                            title = "Contact Us",
+                            icon = Icons.Default.Email,
+                            contentDescription = "Contact Us",
+                            onClick = { contactSupport(context, snackbarHostState, scope) }
+                        )
+                    }
+                }
+            }
+
+            item {
+                Text(
+                    text = "Build Info",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+            }
+
+            item {
+                Card(
+                    shape = RoundedCornerShape(24.dp),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 3.dp)
+                ) {
+                    Column {
+                        KeyValueRow("Build Number", versionName)
+                        Divider()
+                        KeyValueRow("Build Code", versionCode)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsItem(
+    title: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(imageVector = icon, contentDescription = contentDescription)
+        Spacer(Modifier.width(16.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f)
+        )
+        Icon(
+            imageVector = Icons.Default.ChevronRight,
+            contentDescription = null
+        )
+    }
+}
+
+@Composable
+private fun KeyValueRow(key: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = key,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontWeight = FontWeight.Medium,
+                fontFamily = FontFamily.Monospace
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AppSettingsScreenPreview() {
+    AppSettingsScreen(onBack = {}, onOpenUrl = {})
+}
+
+@Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun AppSettingsScreenDarkPreview() {
+    AppSettingsScreen(onBack = {}, onOpenUrl = {})
+}
+

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/util/Intents.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/util/Intents.kt
@@ -1,0 +1,53 @@
+package researchstack.presentation.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.material3.SnackbarHostState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+const val ABOUT_URL = "https://example.com/about"
+const val PRIVACY_URL = "https://example.com/privacy"
+
+fun openUrl(context: Context, url: String) {
+    val uri = Uri.parse(url)
+    val customTabsIntent = CustomTabsIntent.Builder().build()
+    val packageManager = context.packageManager
+    if (customTabsIntent.intent.resolveActivity(packageManager) != null) {
+        customTabsIntent.launchUrl(context, uri)
+    } else {
+        val viewIntent = Intent(Intent.ACTION_VIEW, uri)
+        if (viewIntent.resolveActivity(packageManager) != null) {
+            context.startActivity(viewIntent)
+        } else {
+            Toast.makeText(context, "No browser available", Toast.LENGTH_LONG).show()
+        }
+    }
+}
+
+fun contactSupport(
+    context: Context,
+    snackbarHostState: SnackbarHostState? = null,
+    coroutineScope: CoroutineScope? = null
+) {
+    val intent = Intent(Intent.ACTION_SENDTO).apply {
+        data = Uri.parse("mailto:")
+        putExtra(Intent.EXTRA_EMAIL, arrayOf("alexa.skill.89@gmail.com"))
+        putExtra(Intent.EXTRA_SUBJECT, "Test Subject")
+    }
+    if (intent.resolveActivity(context.packageManager) != null) {
+        context.startActivity(intent)
+    } else {
+        val message = "No email app found"
+        if (snackbarHostState != null && coroutineScope != null) {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar(message)
+            }
+        } else {
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add premium AppSettingsScreen with about, privacy, contact and build info sections
- add Settings tab and route in navigation with icon
- implement URL and email intent helpers

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc55c6324832fae4ac43c28bc8e0f