### PR TITLE
Use email prefix as profile first name on login

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/welcome/WelcomeViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/welcome/WelcomeViewModel.kt
@@ -157,7 +157,13 @@ class WelcomeViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             signInUseCase(auth)
                 .mapCatching {
-                    registerProfileUseCase(anonymousUser)
+                    val email = _uiState.value.email
+                    registerProfileUseCase(
+                        anonymousUser.copy(
+                            firstName = email.substringBefore("@"),
+                            email = email,
+                        )
+                    )
                 }.onSuccess {
                     _registerState.value = Success
                     fetchStudy()


### PR DESCRIPTION
## Summary
- populate user profile first name using the portion of the login email before '@'

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df49b9608832fb8b5271d64f4ed53