### PR TITLE
feat: support username-based login

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/validator/LoginInputNormalizer.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/validator/LoginInputNormalizer.kt
@@ -1,0 +1,14 @@
+package researchstack.domain.validator
+
+/** Normalizes login input by appending a default domain when missing. */
+object LoginInputNormalizer {
+    private const val DEFAULT_DOMAIN = "@gmail.com"
+
+    /**
+     * Returns [input] unchanged if it already contains a domain. Otherwise, appends
+     * [DEFAULT_DOMAIN] to treat [input] as a username.
+     */
+    fun normalize(input: String): String {
+        return if (input.contains('@')) input else input + DEFAULT_DOMAIN
+    }
+}

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/welcome/WelcomeViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/welcome/WelcomeViewModel.kt
@@ -31,6 +31,7 @@ import researchstack.domain.usecase.ReLoginUseCase
 import researchstack.domain.usecase.profile.GetProfileUseCase
 import researchstack.domain.usecase.profile.RegisterProfileUseCase
 import researchstack.domain.validator.EmailValidator
+import researchstack.domain.validator.LoginInputNormalizer
 import researchstack.domain.validator.PasswordValidator
 import researchstack.presentation.worker.FetchStudyWorker
 import researchstack.presentation.worker.WorkerRegistrar.registerAllPeriodicWorkers
@@ -118,7 +119,10 @@ class WelcomeViewModel @Inject constructor(
     }
 
     private fun validateAndLogin() {
-        val emailResult = EmailValidator.validate(_uiState.value.email)
+        val normalizedEmail = LoginInputNormalizer.normalize(_uiState.value.email)
+        _uiState.update { it.copy(email = normalizedEmail) }
+
+        val emailResult = EmailValidator.validate(normalizedEmail)
         val passwordResult = PasswordValidator.validate(_uiState.value.password)
 
         _uiState.update {
@@ -130,7 +134,7 @@ class WelcomeViewModel @Inject constructor(
 
         val firstError = emailResult.errorMessage ?: passwordResult.errorMessage
         if (firstError == null) {
-            registerUser(BasicAuthentication(_uiState.value.email, _uiState.value.password))
+            registerUser(BasicAuthentication(normalizedEmail, _uiState.value.password))
         }
     }
 

--- a/samples/starter-mobile-app/src/test/kotlin/researchstack/domain/validator/LoginInputNormalizerTest.kt
+++ b/samples/starter-mobile-app/src/test/kotlin/researchstack/domain/validator/LoginInputNormalizerTest.kt
@@ -1,0 +1,18 @@
+package researchstack.domain.validator
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LoginInputNormalizerTest {
+    @Test
+    fun `normalize adds gmail domain when missing`() {
+        val result = LoginInputNormalizer.normalize("username")
+        assertEquals("username@gmail.com", result)
+    }
+
+    @Test
+    fun `normalize leaves existing email unchanged`() {
+        val result = LoginInputNormalizer.normalize("user@example.com")
+        assertEquals("user@example.com", result)
+    }
+}


### PR DESCRIPTION
## Summary
- normalize login input to add `@gmail.com` when username lacks domain
- update login validation to use normalized email
- add unit tests for login input normalizer

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a82e892308832f9bb61a4557e791f6