### PR TITLE
Add user profile metrics to compliance entries

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/ResearchAppDatabase.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/datasource/local/room/ResearchAppDatabase.kt
@@ -39,7 +39,7 @@ import researchstack.domain.model.sensor.Accelerometer
 import researchstack.domain.model.sensor.Light
 
 @Database(
-    version = 9,
+    version = 10,
     exportSchema = false,
     entities = [
         StudyEntity::class,
@@ -83,6 +83,14 @@ abstract class ResearchAppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: ResearchAppDatabase? = null
 
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE $COMPLIANCE_ENTRY_TABLE_NAME ADD COLUMN height REAL NOT NULL DEFAULT 0")
+                db.execSQL("ALTER TABLE $COMPLIANCE_ENTRY_TABLE_NAME ADD COLUMN age INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("ALTER TABLE $COMPLIANCE_ENTRY_TABLE_NAME ADD COLUMN gender INTEGER NOT NULL DEFAULT 2")
+            }
+        }
+
         fun getDatabase(
             context: Context,
         ): ResearchAppDatabase =
@@ -92,6 +100,7 @@ abstract class ResearchAppDatabase : RoomDatabase() {
                     ResearchAppDatabase::class.java,
                     "research_app_db"
                 )
+                    .addMigrations(MIGRATION_9_10)
                     .fallbackToDestructiveMigration()
                     .addTypeConverter(EligibilityConverter())
                     .addTypeConverter(LocalDateTimeConverter())

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/data/repository/healthConnect/HealthConnectDataSyncRepositoryImpl.kt
@@ -21,6 +21,7 @@ import researchstack.domain.model.Study
 import researchstack.domain.model.TimestampMapData
 import researchstack.domain.model.healthConnect.Exercise
 import researchstack.domain.model.ComplianceEntry
+import researchstack.domain.model.Gender
 import researchstack.domain.model.shealth.HealthDataModel
 import researchstack.domain.model.shealth.SHealthDataType
 import researchstack.domain.repository.ShareAgreementRepository
@@ -248,6 +249,13 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
             val weightEntries = userProfileDao.getBetween(startMillis, endMillis).first()
             val weightCount = weightEntries.size
             val avgWeight = if (weightEntries.isEmpty()) 0f else weightEntries.map { it.weight }.first()
+            val height = if (weightEntries.isEmpty()) 0f else weightEntries.map { it.height }.first()
+            val age = if (weightEntries.isEmpty()) 0 else {
+                val yearBirth = weightEntries.map { it.yearBirth }.first()
+                val calculated = today.year - yearBirth
+                if (calculated < 0) 0 else calculated
+            }
+            val gender = if (weightEntries.isEmpty()) Gender.UNKNOWN.ordinal else weightEntries.map { it.gender.ordinal }.first()
             entries.add(
                 ComplianceEntry(
                     weekNumber = weekNumber,
@@ -259,6 +267,9 @@ class HealthConnectDataSyncRepositoryImpl @Inject constructor(
                     biaRecordCount = biaCount,
                     weightRecordCount = weightCount,
                     avgWeight = avgWeight,
+                    height = height,
+                    age = age,
+                    gender = gender,
                     id = authenticationPref.getAuthInfo()?.id + weekNumber.toString()
                 )
             )

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/model/ComplianceEntry.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/domain/model/ComplianceEntry.kt
@@ -21,6 +21,12 @@ data class ComplianceEntry(
     val weightRecordCount: Int,
     @ColumnInfo(defaultValue = "0")
     val avgWeight: Float = 0F,
+    @ColumnInfo(defaultValue = "0")
+    val height: Float = 0F,
+    @ColumnInfo(defaultValue = "0")
+    val age: Int = 0,
+    @ColumnInfo(defaultValue = "2")
+    val gender: Int = 2,
     override val timeOffset: Int = getCurrentTimeOffset(),
 ) : TimestampMapData {
     override fun toDataMap(): Map<String, Any> = mapOf(
@@ -34,6 +40,9 @@ data class ComplianceEntry(
         ::biaRecordCount.name to biaRecordCount,
         ::weightRecordCount.name to weightRecordCount,
         ::avgWeight.name to avgWeight,
+        ::height.name to height,
+        ::age.name to age,
+        ::gender.name to gender,
         ::timeOffset.name to timeOffset,
     )
 }


### PR DESCRIPTION
## Summary
- Track user profile metrics (height, age, gender) alongside weight when generating compliance entries
- Extend ComplianceEntry entity and mapping with new fields
- Add Room migration to persist new columns in ResearchAppDatabase

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c157ef5900832fafcb7061947f5011