### PR TITLE
Add debug screen for study registration and permissions

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
@@ -18,6 +18,7 @@ enum class Route {
     Progress,
     WeeklyProgress,
     Rewards,
+    Debug,
 }
 
 enum class MainPage {

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -10,6 +10,7 @@ import researchstack.presentation.screen.insight.SettingScreen
 import researchstack.presentation.screen.insight.StudyPermissionSettingScreen
 import researchstack.presentation.screen.insight.StudyStatusScreen
 import researchstack.presentation.screen.main.AboutUsScreen
+import researchstack.presentation.screen.main.DebugScreen
 import researchstack.presentation.screen.main.MainScreen
 import researchstack.presentation.screen.main.ProgressScreen
 import researchstack.presentation.screen.main.RewardsScreen
@@ -104,6 +105,9 @@ fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) 
         }
         composable(Route.AboutUs.name) {
             AboutUsScreen()
+        }
+        composable(Route.Debug.name) {
+            DebugScreen()
         }
     }
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/AppSettingsScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/AppSettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Insights
@@ -137,6 +138,12 @@ fun AppSettingsScreen() {
                         icon = Icons.Filled.Insights,
                         label = stringResource(id = R.string.weekly_progress),
                         onClick = { navController.navigate(Route.WeeklyProgress.name) }
+                    )
+                    Divider(color = Color(0xFF3D3D3D))
+                    SettingsRow(
+                        icon = Icons.Filled.BugReport,
+                        label = stringResource(id = R.string.debug),
+                        onClick = { navController.navigate(Route.Debug.name) }
                     )
                 }
             }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DebugScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DebugScreen.kt
@@ -1,0 +1,92 @@
+package researchstack.presentation.screen.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import researchstack.R
+import researchstack.presentation.LocalNavController
+import researchstack.presentation.viewmodel.DebugViewModel
+
+@Composable
+fun DebugScreen(viewModel: DebugViewModel = hiltViewModel()) {
+    val navController = LocalNavController.current
+    val hasJoinedStudy = viewModel.hasJoinedStudy.collectAsState().value
+    val allPermissionsGranted = viewModel.allPermissionsGranted.collectAsState().value
+
+    Scaffold(
+        containerColor = Color(0xFF222222),
+        topBar = {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black)
+                    .padding(16.dp)
+            ) {
+                IconButton(
+                    onClick = { navController.popBackStack() },
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(id = R.string.close),
+                        tint = Color.White
+                    )
+                }
+                Text(
+                    text = stringResource(id = R.string.debug),
+                    color = Color.White,
+                    fontSize = 20.sp,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(horizontal = 24.dp)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(
+                    id = R.string.debug_registered_study,
+                    if (hasJoinedStudy) "Yes" else "No"
+                ),
+                color = Color.White,
+                fontSize = 16.sp
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(
+                    id = R.string.debug_permissions_granted,
+                    if (allPermissionsGranted) "Yes" else "No"
+                ),
+                color = Color.White,
+                fontSize = 16.sp
+            )
+        }
+    }
+}
+

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DebugViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DebugViewModel.kt
@@ -1,0 +1,65 @@
+package researchstack.presentation.viewmodel
+
+import android.app.Application
+import android.content.pm.PackageManager
+import android.content.pm.PermissionInfo
+import android.os.Build
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import researchstack.domain.usecase.study.GetJoinedStudiesUseCase
+import javax.inject.Inject
+
+@HiltViewModel
+class DebugViewModel @Inject constructor(
+    application: Application,
+    private val getJoinedStudiesUseCase: GetJoinedStudiesUseCase,
+) : AndroidViewModel(application) {
+
+    private val _hasJoinedStudy = MutableStateFlow(false)
+    val hasJoinedStudy: StateFlow<Boolean> = _hasJoinedStudy
+
+    private val _allPermissionsGranted = MutableStateFlow(false)
+    val allPermissionsGranted: StateFlow<Boolean> = _allPermissionsGranted
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            getJoinedStudiesUseCase().collect { studies ->
+                _hasJoinedStudy.value = studies.isNotEmpty()
+            }
+        }
+        checkPermissions()
+    }
+
+    private fun checkPermissions() {
+        val context = getApplication<Application>().applicationContext
+        val pm = context.packageManager
+        val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pm.getPackageInfo(
+                context.packageName,
+                PackageManager.PackageInfoFlags.of(PackageManager.GET_PERMISSIONS.toLong())
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            pm.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+        }
+        val requested = packageInfo.requestedPermissions ?: emptyArray()
+        val dangerous = requested.filter { perm ->
+            try {
+                val info = pm.getPermissionInfo(perm, 0)
+                info.protectionLevel and PermissionInfo.PROTECTION_DANGEROUS != 0
+            } catch (_: Exception) {
+                false
+            }
+        }
+        _allPermissionsGranted.value = dangerous.all { perm ->
+            ContextCompat.checkSelfPermission(context, perm) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+}
+

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -8,6 +8,9 @@
   <string name="build_number">Build Number</string>
   <string name="build_code">Build Code</string>
   <string name="no_app_found">No application found to handle this action.</string>
+  <string name="debug">Debug</string>
+  <string name="debug_registered_study">Registered in study: %1$s</string>
+  <string name="debug_permissions_granted">All permissions granted: %1$s</string>
   <string name="join_a_study">Join a study</string>
   <string name="join_in_study_message">Go to Join In to join a study</string>
   <string name="no_registered_message">You have no registered studies</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -67,6 +67,9 @@
   <string name="build_number">빌드 번호</string>
   <string name="build_code">빌드 코드</string>
   <string name="no_app_found">이 작업을 처리할 앱이 없습니다.</string>
+  <string name="debug">디버그</string>
+  <string name="debug_registered_study">연구 등록 여부: %1$s</string>
+  <string name="debug_permissions_granted">권한 허용 여부: %1$s</string>
   <string name="data_permission">데이터 권한</string>
   <string name="samsung_health">삼성 헬스</string>
   <string name="sensor">모바일 센서 데이터</string>


### PR DESCRIPTION
## Summary
- Add Debug screen accessible from App Settings
- Show whether user joined any study and if all dangerous permissions are granted
- Wire Debug route into navigation and provide strings

## Testing
- `./gradlew :samples:starter-mobile-app:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f3ba20cc832fa0bf95fb12bd8be0