### PR TITLE
feat(debug): show permissions and joined studies

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DebugScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DebugScreen.kt
@@ -30,8 +30,9 @@ import researchstack.presentation.viewmodel.DebugViewModel
 @Composable
 fun DebugScreen(viewModel: DebugViewModel = hiltViewModel()) {
     val navController = LocalNavController.current
-    val hasJoinedStudy = viewModel.hasJoinedStudy.collectAsState().value
-    val allPermissionsGranted = viewModel.allPermissionsGranted.collectAsState().value
+    val joinedStudies = viewModel.joinedStudies.collectAsState().value
+    val grantedPermissions = viewModel.grantedPermissions.collectAsState().value
+    val notGrantedPermissions = viewModel.notGrantedPermissions.collectAsState().value
 
     Scaffold(
         containerColor = Color(0xFF222222),
@@ -71,8 +72,8 @@ fun DebugScreen(viewModel: DebugViewModel = hiltViewModel()) {
             Spacer(modifier = Modifier.height(24.dp))
             Text(
                 text = stringResource(
-                    id = R.string.debug_registered_study,
-                    if (hasJoinedStudy) "Yes" else "No"
+                    id = R.string.debug_joined_studies,
+                    if (joinedStudies.isEmpty()) "None" else joinedStudies.joinToString()
                 ),
                 color = Color.White,
                 fontSize = 16.sp
@@ -80,8 +81,17 @@ fun DebugScreen(viewModel: DebugViewModel = hiltViewModel()) {
             Spacer(modifier = Modifier.height(12.dp))
             Text(
                 text = stringResource(
-                    id = R.string.debug_permissions_granted,
-                    if (allPermissionsGranted) "Yes" else "No"
+                    id = R.string.debug_granted_permissions,
+                    if (grantedPermissions.isEmpty()) "None" else grantedPermissions.joinToString()
+                ),
+                color = Color.White,
+                fontSize = 16.sp
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(
+                    id = R.string.debug_not_granted_permissions,
+                    if (notGrantedPermissions.isEmpty()) "None" else notGrantedPermissions.joinToString()
                 ),
                 color = Color.White,
                 fontSize = 16.sp

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -9,8 +9,9 @@
   <string name="build_code">Build Code</string>
   <string name="no_app_found">No application found to handle this action.</string>
   <string name="debug">Debug</string>
-  <string name="debug_registered_study">Registered in study: %1$s</string>
-  <string name="debug_permissions_granted">All permissions granted: %1$s</string>
+  <string name="debug_joined_studies">Joined studies: %1$s</string>
+  <string name="debug_granted_permissions">Granted permissions: %1$s</string>
+  <string name="debug_not_granted_permissions">Not granted permissions: %1$s</string>
   <string name="join_a_study">Join a study</string>
   <string name="join_in_study_message">Go to Join In to join a study</string>
   <string name="no_registered_message">You have no registered studies</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -68,8 +68,9 @@
   <string name="build_code">빌드 코드</string>
   <string name="no_app_found">이 작업을 처리할 앱이 없습니다.</string>
   <string name="debug">디버그</string>
-  <string name="debug_registered_study">연구 등록 여부: %1$s</string>
-  <string name="debug_permissions_granted">권한 허용 여부: %1$s</string>
+  <string name="debug_joined_studies">참여 중인 연구: %1$s</string>
+  <string name="debug_granted_permissions">허용된 권한: %1$s</string>
+  <string name="debug_not_granted_permissions">허용되지 않은 권한: %1$s</string>
   <string name="data_permission">데이터 권한</string>
   <string name="samsung_health">삼성 헬스</string>
   <string name="sensor">모바일 센서 데이터</string>


### PR DESCRIPTION
## Summary
- show lists of joined studies and granted/denied permissions in debug screen
- expose lists of joined studies and permissions in DebugViewModel

## Testing
- `./gradlew :samples:starter-mobile-app:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f56f5a48832f9389b513886fab09