### PR TITLE
feat: add permission buttons to debug screen

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DebugScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DebugScreen.kt
@@ -1,5 +1,7 @@
 package researchstack.presentation.screen.main
 
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,29 +12,58 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.launch
 import researchstack.R
 import researchstack.presentation.LocalNavController
 import researchstack.presentation.viewmodel.DebugViewModel
+import researchstack.presentation.viewmodel.HealthConnectPermissionViewModel
 
 @Composable
-fun DebugScreen(viewModel: DebugViewModel = hiltViewModel()) {
+fun DebugScreen(
+    viewModel: DebugViewModel = hiltViewModel(),
+    healthConnectPermissionViewModel: HealthConnectPermissionViewModel = hiltViewModel(),
+) {
     val navController = LocalNavController.current
     val joinedStudies = viewModel.joinedStudies.collectAsState().value
     val grantedPermissions = viewModel.grantedPermissions.collectAsState().value
     val notGrantedPermissions = viewModel.notGrantedPermissions.collectAsState().value
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    var missingHealthPermissions by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var samsungPermissionsGranted by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        missingHealthPermissions = healthConnectPermissionViewModel.getMissingPermissions()
+        samsungPermissionsGranted = healthConnectPermissionViewModel.areSamsungPermissionsGranted()
+    }
+
+    val permissionsLauncher =
+        rememberLauncherForActivityResult(healthConnectPermissionViewModel.permissionsLauncher) { granted ->
+            coroutineScope.launch {
+                missingHealthPermissions = healthConnectPermissionViewModel.getMissingPermissions()
+            }
+        }
 
     Scaffold(
         containerColor = Color(0xFF222222),
@@ -96,6 +127,27 @@ fun DebugScreen(viewModel: DebugViewModel = hiltViewModel()) {
                 color = Color.White,
                 fontSize = 16.sp
             )
+            if (missingHealthPermissions.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(onClick = {
+                    permissionsLauncher.launch(healthConnectPermissionViewModel.allPermissions)
+                }) {
+                    Text(text = stringResource(id = R.string.grant_health_permissions))
+                }
+            }
+            if (!samsungPermissionsGranted) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(onClick = {
+                    (context as? Activity)?.let { activity ->
+                        healthConnectPermissionViewModel.requestSamsungPermissions(activity)
+                        coroutineScope.launch {
+                            samsungPermissionsGranted = healthConnectPermissionViewModel.areSamsungPermissionsGranted()
+                        }
+                    }
+                }) {
+                    Text(text = stringResource(id = R.string.grant_samsung_health_permissions))
+                }
+            }
         }
     }
 }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/HealthConnectPermissionViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/HealthConnectPermissionViewModel.kt
@@ -124,6 +124,10 @@ class HealthConnectPermissionViewModel @Inject constructor(
         }
     }
 
+    suspend fun areSamsungPermissionsGranted(): Boolean {
+        return arePermissionsGrantedUseCase()
+    }
+
 
     /**
      * Provides permission check and error handling for Health Connect suspend function calls.

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -69,6 +69,8 @@
   <string name="study_permission_title">Data Information</string>
   <string name="data_permission">Data Permissions</string>
   <string name="samsung_health">Samsung Health</string>
+  <string name="grant_health_permissions">Grant Android Health permissions</string>
+  <string name="grant_samsung_health_permissions">Grant Samsung Health access</string>
   <string name="sensor">Mobile sensor data</string>
   <string name="priv_data">Wearable sensor data</string>
   <string name="device_stats">Device Status</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
   <string name="debug_joined_studies">참여 중인 연구: %1$s</string>
   <string name="debug_granted_permissions">허용된 권한: %1$s</string>
   <string name="debug_not_granted_permissions">허용되지 않은 권한: %1$s</string>
+  <string name="grant_health_permissions">Android Health 권한 허용</string>
+  <string name="grant_samsung_health_permissions">Samsung Health 권한 허용</string>
   <string name="data_permission">데이터 권한</string>
   <string name="samsung_health">삼성 헬스</string>
   <string name="sensor">모바일 센서 데이터</string>


### PR DESCRIPTION
## Summary
- add buttons to request Android Health and Samsung Health permissions from debug screen
- expose method to check Samsung Health permission state

## Testing
- `./gradlew :samples:starter-mobile-app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f8563c9c832f82e864f94023dcb0