### PR TITLE
Avoid repeated dashboard sync on navigation return

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/screen/main/DashboardScreen.kt
@@ -66,6 +66,8 @@ import researchstack.presentation.viewmodel.HealthConnectPermissionViewModel
 import researchstack.presentation.viewmodel.DashboardViewModel
 import java.time.format.DateTimeFormatter
 
+private var hasPerformedInitialSync = false
+
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun DashboardScreen(
@@ -148,7 +150,10 @@ fun DashboardScreen(
     val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = performSync)
 
     LaunchedEffect(Unit) {
-        performSync()
+        if (!hasPerformedInitialSync) {
+            hasPerformedInitialSync = true
+            performSync()
+        }
     }
 
     LaunchedEffect(exercises) {


### PR DESCRIPTION
## Summary
- track initial sync with flag to run automatic performSync only once

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c41b4734c0832fb2c9866c4a502e78