### PR TITLE
Prompt Health Connect install when missing

### DIFF
--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -67,6 +67,9 @@
   <string name="build_number">빌드 번호</string>
   <string name="build_code">빌드 코드</string>
   <string name="no_app_found">이 작업을 처리할 앱이 없습니다.</string>
+  <string name="health_connect_required_title">Health Connect required</string>
+  <string name="health_connect_required_message">Install the Health Connect app from Google Play to continue.</string>
+  <string name="install">Install</string>
   <string name="debug">디버그</string>
   <string name="debug_joined_studies">참여 중인 연구: %1$s</string>
   <string name="debug_granted_permissions">허용된 권한: %1$s</string>


### PR DESCRIPTION
## Summary
- emit a splash screen event when Health Connect is unavailable so the install flow can be triggered
- prompt the user from MainActivity to install Health Connect via Google Play before loading the rest of the app
- add string resources for the Health Connect install dialog

## Testing
- ./gradlew :samples:starter-mobile-app:assembleDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc7398708832fa3c5a87644d435a1