### PR TITLE
Add Health Connect install screen

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/screen/HealthConnectUnavailableScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/screen/HealthConnectUnavailableScreen.kt
@@ -1,0 +1,61 @@
+package researchstack.presentation.initiate.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import researchstack.R
+
+@Composable
+fun HealthConnectUnavailableScreen(
+    onInstallHealthConnect: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp)
+            .padding(top = 64.dp, bottom = 32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(id = R.string.health_connect_required_title),
+            style = MaterialTheme.typography.h5,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(id = R.string.health_connect_required_message),
+            style = MaterialTheme.typography.body1,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+        Button(
+            onClick = onInstallHealthConnect,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = stringResource(id = R.string.install))
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        OutlinedButton(
+            onClick = onRetry,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = stringResource(id = R.string.health_connect_retry))
+        }
+    }
+}

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
   <string name="no_app_found">이 작업을 처리할 앱이 없습니다.</string>
   <string name="health_connect_required_title">Health Connect required</string>
   <string name="health_connect_required_message">Install the Health Connect app from Google Play to continue.</string>
+  <string name="health_connect_retry">Check again</string>
   <string name="install">Install</string>
   <string name="debug">디버그</string>
   <string name="debug_joined_studies">참여 중인 연구: %1$s</string>


### PR DESCRIPTION
## Summary
- add a composable screen that guides users to install Health Connect when it is missing
- update MainActivity to surface the new screen instead of a dialog and to retry availability checks
- adjust SplashLoadingViewModel and strings to expose Health Connect status for the UI

## Testing
- ./gradlew :samples:starter-mobile-app:assembleDebug *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbccfb714c832fba282c4ded103855