### PR TITLE
Route Health Connect unavailable through nav graph

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/MainActivity.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/MainActivity.kt
@@ -23,7 +23,6 @@ import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import researchstack.R
 import researchstack.presentation.LocalNavController
-import researchstack.presentation.initiate.screen.HealthConnectUnavailableScreen
 import researchstack.presentation.initiate.route.Route
 import researchstack.presentation.initiate.route.Router
 import researchstack.presentation.theme.AppTheme
@@ -48,24 +47,15 @@ class MainActivity : ComponentActivity() {
         setContent {
             val startDestination: Route? by splashLoadingViewModel.routeDestination.observeAsState()
             val page by splashLoadingViewModel.startMainPage.observeAsState(0)
-            val isHealthConnectAvailable by splashLoadingViewModel.healthConnectAvailable.observeAsState()
             val openWeeklyProgress = intent.getBooleanExtra("openWeeklyProgress", false)
 
             AppTheme {
-                when {
-                    isHealthConnectAvailable == false -> {
-                        HealthConnectUnavailableScreen(
-                            onInstallHealthConnect = { openHealthConnectInPlayStore() },
-                            onRetry = { handleHealthConnectRetry() }
-                        )
-                    }
-                    startDestination != null -> {
-                        ContentComposable(
-                            startDestination = startDestination!!,
-                            page = page,
-                            openWeeklyProgress = openWeeklyProgress,
-                        )
-                    }
+                startDestination?.let { destination ->
+                    ContentComposable(
+                        startDestination = destination,
+                        page = page,
+                        openWeeklyProgress = openWeeklyProgress,
+                    )
                 }
             }
         }
@@ -108,6 +98,8 @@ class MainActivity : ComponentActivity() {
                     navController = navController,
                     startRoute = startDestination,
                     askedPage = intent.getIntExtra("page", page),
+                    onInstallHealthConnect = { openHealthConnectInPlayStore() },
+                    onHealthConnectRetry = { handleHealthConnectRetry() },
                 )
                 if (openWeeklyProgress) {
                     androidx.compose.runtime.LaunchedEffect(Unit) {

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Route.kt
@@ -1,6 +1,7 @@
 package researchstack.presentation.initiate.route
 
 enum class Route {
+    HealthConnectUnavailable,
     Welcome,
     Main,
     StudyCode,

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import researchstack.presentation.initiate.screen.HealthConnectUnavailableScreen
 import researchstack.presentation.screen.insight.SettingScreen
 import researchstack.presentation.screen.insight.StudyPermissionSettingScreen
 import researchstack.presentation.screen.insight.StudyStatusScreen
@@ -29,10 +30,22 @@ import researchstack.presentation.screen.welcome.WelcomeScreen
 private val mainRouteName = "${Route.Main.name}/{page}"
 
 @Composable
-fun Router(navController: NavHostController, startRoute: Route, askedPage: Int) {
+fun Router(
+    navController: NavHostController,
+    startRoute: Route,
+    askedPage: Int,
+    onInstallHealthConnect: () -> Unit,
+    onHealthConnectRetry: () -> Unit,
+) {
     val startDestination = startRoute.name
 
     NavHost(navController = navController, startDestination = startDestination) {
+        composable(Route.HealthConnectUnavailable.name) {
+            HealthConnectUnavailableScreen(
+                onInstallHealthConnect = onInstallHealthConnect,
+                onRetry = onHealthConnectRetry,
+            )
+        }
         composable(Route.Intro.name) {
             AppIntroScreen()
         }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/SplashLoadingViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/SplashLoadingViewModel.kt
@@ -38,8 +38,8 @@ class SplashLoadingViewModel @Inject constructor(
 
     fun setStartRouteDestination(): Boolean {
         if (!ensureHealthConnectAvailable()) {
+            _routeDestination.postValue(Route.HealthConnectUnavailable)
             _isReady.postValue(true)
-            _routeDestination.postValue(null)
             return false
         }
         viewModelScope.launch {


### PR DESCRIPTION
## Summary
- route the Health Connect unavailable experience through the navigation graph
- update the splash loading view model to surface the new start destination when Health Connect is missing

## Testing
- ./gradlew :samples:starter-mobile-app:lint *(fails: missing Android SDK in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd16c8190832f9402e44233e0d79e