### PR TITLE
Add Samsung Health availability checks for onboarding

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/route/Router.kt
@@ -35,14 +35,20 @@ fun Router(
     startRoute: Route,
     askedPage: Int,
     onInstallHealthConnect: () -> Unit,
+    onInstallSamsungHealth: () -> Unit,
     onHealthConnectRetry: () -> Unit,
+    isHealthConnectAvailable: Boolean?,
+    isSamsungHealthAvailable: Boolean?,
 ) {
     val startDestination = startRoute.name
 
     NavHost(navController = navController, startDestination = startDestination) {
         composable(Route.HealthConnectUnavailable.name) {
             HealthConnectUnavailableScreen(
+                showHealthConnectButton = isHealthConnectAvailable != true,
+                showSamsungHealthButton = isSamsungHealthAvailable != true,
                 onInstallHealthConnect = onInstallHealthConnect,
+                onInstallSamsungHealth = onInstallSamsungHealth,
                 onRetry = onHealthConnectRetry,
             )
         }

--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/screen/HealthConnectUnavailableScreen.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/initiate/screen/HealthConnectUnavailableScreen.kt
@@ -1,5 +1,7 @@
 package researchstack.presentation.initiate.screen
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,25 +10,35 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import researchstack.R
 
+private val BackgroundColor = Color(0xFF222222)
+private val HealthConnectButtonColor = Color(0xFF2B9179)
+private val SamsungHealthButtonColor = Color(0xFF287CC3)
+
 @Composable
 fun HealthConnectUnavailableScreen(
+    showHealthConnectButton: Boolean,
+    showSamsungHealthButton: Boolean,
     onInstallHealthConnect: () -> Unit,
+    onInstallSamsungHealth: () -> Unit,
     onRetry: () -> Unit,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .background(BackgroundColor)
             .padding(horizontal = 24.dp)
             .padding(top = 64.dp, bottom = 32.dp),
         verticalArrangement = Arrangement.Center,
@@ -36,24 +48,78 @@ fun HealthConnectUnavailableScreen(
             text = stringResource(id = R.string.health_connect_required_title),
             style = MaterialTheme.typography.h5,
             textAlign = TextAlign.Center,
+            color = Color.White,
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = stringResource(id = R.string.health_connect_required_message),
-            style = MaterialTheme.typography.body1,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(modifier = Modifier.height(32.dp))
-        Button(
-            onClick = onInstallHealthConnect,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(text = stringResource(id = R.string.install))
+
+        if (showHealthConnectButton) {
+            Text(
+                text = stringResource(id = R.string.health_connect_required_message),
+                style = MaterialTheme.typography.body1,
+                textAlign = TextAlign.Center,
+                color = Color.White,
+            )
         }
-        Spacer(modifier = Modifier.height(12.dp))
+
+        if (showSamsungHealthButton) {
+            if (showHealthConnectButton) {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+            Text(
+                text = stringResource(id = R.string.samsung_health_required_message),
+                style = MaterialTheme.typography.body1,
+                textAlign = TextAlign.Center,
+                color = Color.White,
+            )
+        }
+
+        if (!showHealthConnectButton && !showSamsungHealthButton) {
+            Text(
+                text = stringResource(id = R.string.health_connect_required_message),
+                style = MaterialTheme.typography.body1,
+                textAlign = TextAlign.Center,
+                color = Color.White,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        if (showHealthConnectButton) {
+            Button(
+                onClick = onInstallHealthConnect,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = HealthConnectButtonColor,
+                    contentColor = Color.White,
+                )
+            ) {
+                Text(text = stringResource(id = R.string.install_health_connect))
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        if (showSamsungHealthButton) {
+            Button(
+                onClick = onInstallSamsungHealth,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = SamsungHealthButtonColor,
+                    contentColor = Color.White,
+                )
+            ) {
+                Text(text = stringResource(id = R.string.install_samsung_health))
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
         OutlinedButton(
             onClick = onRetry,
             modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = Color.Transparent,
+                contentColor = Color.White,
+            ),
+            border = BorderStroke(1.dp, Color.White),
         ) {
             Text(text = stringResource(id = R.string.health_connect_retry))
         }

--- a/samples/starter-mobile-app/src/main/res/values-en/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values-en/strings.xml
@@ -73,6 +73,10 @@
   <string name="samsung_health">Samsung Health</string>
   <string name="grant_health_permissions">Grant Android Health permissions</string>
   <string name="grant_samsung_health_permissions">Grant Samsung Health access</string>
+  <string name="health_connect_required_message">Install the Health Connect app to continue.</string>
+  <string name="samsung_health_required_message">Install the Samsung Health app to continue.</string>
+  <string name="install_health_connect">Install Health Connect</string>
+  <string name="install_samsung_health">Install Samsung Health</string>
   <string name="sensor">Mobile sensor data</string>
   <string name="priv_data">Wearable sensor data</string>
   <string name="device_stats">Device Status</string>

--- a/samples/starter-mobile-app/src/main/res/values/strings.xml
+++ b/samples/starter-mobile-app/src/main/res/values/strings.xml
@@ -67,10 +67,13 @@
   <string name="build_number">빌드 번호</string>
   <string name="build_code">빌드 코드</string>
   <string name="no_app_found">이 작업을 처리할 앱이 없습니다.</string>
-  <string name="health_connect_required_title">Health Connect required</string>
-  <string name="health_connect_required_message">Install the Health Connect app from Google Play to continue.</string>
+  <string name="health_connect_required_title">Install required health apps</string>
+  <string name="health_connect_required_message">Install the Health Connect app to continue.</string>
   <string name="health_connect_retry">Check again</string>
   <string name="install">Install</string>
+  <string name="samsung_health_required_message">Install the Samsung Health app to continue.</string>
+  <string name="install_health_connect">Install Health Connect</string>
+  <string name="install_samsung_health">Install Samsung Health</string>
   <string name="debug">디버그</string>
   <string name="debug_joined_studies">참여 중인 연구: %1$s</string>
   <string name="debug_granted_permissions">허용된 권한: %1$s</string>


### PR DESCRIPTION
## Summary
- check for both Android Health Connect and Samsung Health at startup and expose availability to navigation
- refresh the HealthConnectUnavailableScreen with dashboard styling and per-app install actions
- wire install intents and strings for Samsung Health so users can resolve missing dependencies

## Testing
- ./gradlew :samples:starter-mobile-app:lint *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd683c908832fb1348a58acd1f108