### PR TITLE
Adjust dashboard compliance thresholds

### DIFF
--- a/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
+++ b/samples/starter-mobile-app/src/main/kotlin/researchstack/presentation/viewmodel/DashboardViewModel.kt
@@ -170,14 +170,24 @@ class DashboardViewModel @Inject constructor(
 
     private fun updateComplianceMessages() {
         val messages = mutableListOf<String>()
-        if (_currentDay.value >= 3 && _totalDurationMinutes.value < WEEKLY_ACTIVITY_GOAL_MINUTES) {
+        val currentDay = _currentDay.value
+        val totalActivityMinutes = _totalDurationMinutes.value
+        if (
+            (currentDay in 3 until 5 && totalActivityMinutes < 50L) ||
+            (currentDay in 5 until 7 && totalActivityMinutes < 100L) ||
+            (currentDay == 7 && totalActivityMinutes < WEEKLY_ACTIVITY_GOAL_MINUTES.toLong())
+        ) {
             messages += getActivityMessage()
         }
-        if (_currentDay.value >= 4 && _resistanceExercises.value.size < WEEKLY_RESISTANCE_SESSION_COUNT) {
+        val resistanceSessions = _resistanceExercises.value.size
+        if (
+            (currentDay in 4 until 7 && resistanceSessions < 1) ||
+            (currentDay == 7 && resistanceSessions < WEEKLY_RESISTANCE_SESSION_COUNT)
+        ) {
             messages += getResistanceMessage()
         }
         if (
-            _currentDay.value == 7 &&
+            currentDay == 7 &&
             (_biaCount.value < MINIMUM_BIA_ENTRIES_PER_WEEK ||
                 _weightCount.value < MINIMUM_WEIGHT_ENTRIES_PER_WEEK)
         ) {


### PR DESCRIPTION
## Summary
- update dashboard compliance logic to use tiered activity checks based on the current day
- refine resistance reminder conditions to require 1 session by day 7 and both sessions by week end
- apply matching tiered compliance thresholds to ComplianceCheckReceiver reminders

## Testing
- ./gradlew :samples:starter-mobile-app:assembleDebug *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2691e8a24832f846cd8575ba0990f